### PR TITLE
[PL-62] [test] 플랜 기능 Repository Test 작성

### DIFF
--- a/src/main/java/com/planit/planit/member/Member.java
+++ b/src/main/java/com/planit/planit/member/Member.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -82,6 +83,9 @@ public class Member extends BaseEntity {
         this.signType = signType;
         this.guiltyFreeMode = guiltyFreeMode;
         this.dailyCondition = dailyCondition;
+        this.plans = new ArrayList<>();
+        this.tasks = new ArrayList<>();
+        this.dreams = new ArrayList<>();
     }
 
 /*------------------------------ METHOD ------------------------------*/

--- a/src/main/java/com/planit/planit/plan/Plan.java
+++ b/src/main/java/com/planit/planit/plan/Plan.java
@@ -43,7 +43,7 @@ public class Plan extends BaseEntity {
     private LocalDateTime finishedAt;   // 플랜 종료일
 
     @Column
-    private LocalDateTime deletedAt;
+    private LocalDateTime inactive;     // 플랜 비활성화(중단, 아카이빙, 삭제)
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
@@ -83,8 +83,31 @@ public class Plan extends BaseEntity {
 
 /*------------------------------ METHOD ------------------------------*/
 
+    public void updatePlan(
+            String title,          String motivation,       String icon,
+            PlanStatus planStatus, LocalDateTime startedAt, LocalDateTime finishedAt
+    ) {
+        this.title = title;
+        this.motivation = motivation;
+        this.icon = icon;
+        this.planStatus = planStatus;
+        this.startedAt = startedAt;
+        this.finishedAt = finishedAt;
+    }
+
+    public void completePlan() {
+        this.planStatus = PlanStatus.ARCHIVED;
+        this.inactive = LocalDateTime.now();
+    }
+
+    public void pausePlan() {
+        this.planStatus = PlanStatus.PAUSED;
+        this.inactive = LocalDateTime.now();
+    }
+
     public void deletePlan() {
-        this.deletedAt = LocalDateTime.now();
+        this.planStatus = PlanStatus.DELETED;
+        this.inactive = LocalDateTime.now();
     }
 
     public int countTasks() { return this.tasks.size(); }

--- a/src/main/java/com/planit/planit/plan/PlanRepository.java
+++ b/src/main/java/com/planit/planit/plan/PlanRepository.java
@@ -1,8 +1,13 @@
 package com.planit.planit.plan;
 
+import com.planit.planit.plan.enums.PlanStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+
+    List<Plan> findAllByMemberIdAndPlanStatus(Long memberId, PlanStatus planStatus);
 }

--- a/src/test/java/com/planit/planit/plan/PlanRepositoryTest.java
+++ b/src/test/java/com/planit/planit/plan/PlanRepositoryTest.java
@@ -1,0 +1,261 @@
+package com.planit.planit.plan;
+
+import com.planit.planit.member.Member;
+import com.planit.planit.member.MemberRepository;
+import com.planit.planit.plan.enums.PlanStatus;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class PlanRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PlanRepository planRepository;
+
+    private Member member;
+    private Plan planInProgress1;
+    private Plan planInProgress2;
+    private Plan pausedPlan1;
+    private Plan pausedPlan2;
+    private Plan archivedPlan1;
+    private Plan archivedPlan2;
+
+    @BeforeEach
+    public void beforeEach() {
+        initMember();               // 회원 더미데이터 생성
+        initPlan();                 // 플랜 더미데이터 생성
+    }
+
+    private void initMember() {
+        member = Member.builder()
+                .email("xxx@email.com")
+                .password("password")
+                .guiltyFreeMode(false)
+                .build();
+    }
+
+    private void initPlan() {
+        planInProgress1 = Plan.builder()
+                .title("1")
+                .motivation("다짐문장")
+                .icon("아이콘")
+                .planStatus(PlanStatus.IN_PROGRESS)
+                .member(member)
+                .build();
+        planInProgress2 = Plan.builder()
+                .title("2")
+                .motivation("다짐문장")
+                .icon("아이콘")
+                .planStatus(PlanStatus.IN_PROGRESS)
+                .member(member)
+                .build();
+        pausedPlan1 = Plan.builder()
+                .title("3")
+                .motivation("다짐문장")
+                .icon("아이콘")
+                .planStatus(PlanStatus.PAUSED)
+                .finishedAt(LocalDateTime.now())
+                .member(member)
+                .build();
+        pausedPlan2 = Plan.builder()
+                .title("4")
+                .motivation("다짐문장")
+                .icon("아이콘")
+                .planStatus(PlanStatus.PAUSED)
+                .finishedAt(LocalDateTime.now().plusDays(1))
+                .member(member)
+                .build();
+        archivedPlan1 = Plan.builder()
+                .title("5")
+                .motivation("다짐문장")
+                .icon("아이콘")
+                .planStatus(PlanStatus.ARCHIVED)
+                .finishedAt(LocalDateTime.now())
+                .member(member)
+                .build();
+        archivedPlan2 = Plan.builder()
+                .title("6")
+                .motivation("다짐문장")
+                .icon("아이콘")
+                .planStatus(PlanStatus.ARCHIVED)
+                .finishedAt(LocalDateTime.now().plusDays(1))
+                .member(member)
+                .build();
+    }
+
+    @Test
+    @Order(1)
+    @Transactional
+    @DisplayName("플랜 저장 테스트 (성공)")
+    public void saveTest() {
+
+        // given
+        member = memberRepository.save(member);
+
+        // when
+        Plan result = planRepository.save(planInProgress1);
+
+        // then
+        assertNotNull(result);
+        assertThat(result.getTitle()).isEqualTo("1");
+        assertThat(result.getPlanStatus()).isEqualTo(PlanStatus.IN_PROGRESS);
+        assertThat(result.getMember().getId()).isEqualTo(member.getId());
+    }
+
+    @Test
+    @Order(2)
+    @Transactional(readOnly = true)
+    @DisplayName("플랜 아이디로 플랜 조회 테스트 (성공)")
+    public void findByIdTest() {
+
+        // given
+        member = memberRepository.save(member);
+        planInProgress1 = planRepository.save(planInProgress1);
+
+        // when
+        Plan result = planRepository.findById(planInProgress1.getId()).get();
+
+        // then
+        assertNotNull(result);
+        assertThat(result.getTitle()).isEqualTo("1");
+        assertThat(result.getPlanStatus()).isEqualTo(PlanStatus.IN_PROGRESS);
+        assertThat(result.getMember().getId()).isEqualTo(member.getId());
+    }
+
+    @Test
+    @Order(3)
+    @Transactional(readOnly = true)
+    @DisplayName("진행중인 플랜 목록 조회 테스트 (성공)")
+    public void findAllByMemberIdAndPlanStatusTest_InProgress() {
+
+        // given
+        member = memberRepository.save(member);
+        planInProgress1 = planRepository.save(planInProgress1);
+        planInProgress2 = planRepository.save(planInProgress2);
+
+        // when
+        List<Plan> result = planRepository.findAllByMemberIdAndPlanStatus(member.getId(), PlanStatus.IN_PROGRESS);
+
+        // then
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0).getTitle()).isEqualTo("2");
+        assertThat(result.get(1).getTitle()).isEqualTo("1");
+    }
+
+    @Test
+    @Order(4)
+    @Transactional(readOnly = true)
+    @DisplayName("중단된 플랜 목록 조회 테스트 (성공)")
+    public void findAllByMemberIdAndPlanStatusTest_Paused() {
+
+        // given
+        member = memberRepository.save(member);
+        pausedPlan1 = planRepository.save(pausedPlan1);
+        pausedPlan2 = planRepository.save(pausedPlan2);
+
+        // when
+        List<Plan> result = planRepository.findAllByMemberIdAndPlanStatus(member.getId(), PlanStatus.PAUSED);
+
+        // then
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0).getTitle()).isEqualTo("4");
+        assertThat(result.get(1).getTitle()).isEqualTo("3");
+    }
+
+    @Test
+    @Order(5)
+    @Transactional(readOnly = true)
+    @DisplayName("아카이빙된 플랜 목록 조회 테스트 (성공)")
+    public void findAllByMemberIdAndPlanStatusTest_Archived() {
+
+        // given
+        member = memberRepository.save(member);
+        archivedPlan1 = planRepository.save(archivedPlan1);
+        archivedPlan2 = planRepository.save(archivedPlan2);
+
+        // when
+        List<Plan> result = planRepository.findAllByMemberIdAndPlanStatus(member.getId(), PlanStatus.ARCHIVED);
+
+        // then
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0).getTitle()).isEqualTo("6");
+        assertThat(result.get(1).getTitle()).isEqualTo("5");
+    }
+
+    @Test
+    @Order(6)
+    @Transactional
+    @DisplayName("플랜 아카이빙 테스트 (성공)")
+    public void completePlanTest() {
+
+        // given
+        member = memberRepository.save(member);
+        planInProgress1 = planRepository.save(planInProgress1);
+
+        // when
+        planInProgress1.completePlan();
+
+        // then
+        Plan result = planRepository.findById(planInProgress1.getId()).get();
+        assertNotNull(result);
+        assertThat(result.getTitle()).isEqualTo("1");
+        assertThat(result.getPlanStatus()).isEqualTo(PlanStatus.ARCHIVED);
+        assertThat(result.getInactive()).isNotNull();
+    }
+
+    @Test
+    @Order(7)
+    @Transactional
+    @DisplayName("플랜 중단 테스트 (성공)")
+    public void pausePlanTest() {
+
+        // given
+        member = memberRepository.save(member);
+        planInProgress1 = planRepository.save(planInProgress1);
+
+        // when
+        planInProgress1.pausePlan();
+
+        // then
+        Plan result = planRepository.findById(planInProgress1.getId()).get();
+        assertNotNull(result);
+        assertThat(result.getTitle()).isEqualTo("1");
+        assertThat(result.getPlanStatus()).isEqualTo(PlanStatus.PAUSED);
+        assertThat(result.getInactive()).isNotNull();
+    }
+
+    @Test
+    @Order(8)
+    @Transactional
+    @DisplayName("플랜 삭제 테스트 (성공)")
+    public void deletePlanTest() {
+
+        // given
+        member = memberRepository.save(member);
+        planInProgress1 = planRepository.save(planInProgress1);
+
+        // when
+        planInProgress1.deletePlan();
+
+        // then
+        Plan result = planRepository.findById(planInProgress1.getId()).get();
+        assertNotNull(result);
+        assertThat(result.getTitle()).isEqualTo("1");
+        assertThat(result.getPlanStatus()).isEqualTo(PlanStatus.DELETED);
+        assertThat(result.getInactive()).isNotNull();
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

> 이슈 번호를 작성해주세요

- #37 

<br>

## 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- PlanRepository의 기능에 대한 테스트 코드를 작성하였습니다.
- `findAllByMemberIdAndPlanStatus` 함수는 커스터마이징이 필요해서 당연히 지금은 테스트가 통과되지 않습니다 ‼️
- member 엔티티에서 deletedAt 필드의 이름을 inactive로 변경하였습니다(++ 아카이빙, 종료, 중단 세 가지 케이스가 있어서 inactive가 조금 더 범용성이 있을 것 같아요).

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- PR 확인해주셔서 감사합니다 :)
