### PR TITLE
[PL-98] [feat] 플랜 기능 1차 구현

### DIFF
--- a/src/main/java/com/planit/planit/common/api/ApiResponse.java
+++ b/src/main/java/com/planit/planit/common/api/ApiResponse.java
@@ -29,23 +29,23 @@ public class ApiResponse<T>  {
     }
 
     // Success
-    public static ApiResponse<Void> onSuccess(SuccessStatus status) {
+    public static ApiResponse<Void> onSuccess(SuccessResponse status) {
         return new ApiResponse<>(status);
     }
 
     // Success with Data
-    public static <T> ApiResponse<T> onSuccess(SuccessStatus status, T data) {
+    public static <T> ApiResponse<T> onSuccess(SuccessResponse status, T data) {
         return new ApiResponse<>(true, status.getCode(), status.getMessage(), data);
 
     }
 
     // Failure
-    public static <T> ApiResponse<T> onFailure(ErrorStatus status) {
+    public static <T> ApiResponse<T> onFailure(ErrorResponse status) {
         return new ApiResponse<>(false, status.getCode(), status.getMessage(), null);
     }
 
     // Failure with Data
-    public static <T> ApiResponse<T> onFailure(ErrorStatus status, T data) {
+    public static <T> ApiResponse<T> onFailure(ErrorResponse status, T data) {
         return new ApiResponse<>(false, status.getCode(), status.getMessage(), data);
     }
 

--- a/src/main/java/com/planit/planit/common/api/member/status/MemberErrorStatus.java
+++ b/src/main/java/com/planit/planit/common/api/member/status/MemberErrorStatus.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum MemberErrorStatus implements ErrorResponse {
 
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "회원을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/planit/planit/common/api/plan/status/PlanErrorStatus.java
+++ b/src/main/java/com/planit/planit/common/api/plan/status/PlanErrorStatus.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum PlanErrorStatus implements ErrorResponse {
 
+    PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN4001", "플랜을 찾을 수 없습니다."),
+    MEMBER_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN4002", "사용자의 플랜을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/planit/planit/common/api/plan/status/PlanSuccessStatus.java
+++ b/src/main/java/com/planit/planit/common/api/plan/status/PlanSuccessStatus.java
@@ -5,7 +5,18 @@ import org.springframework.http.HttpStatus;
 
 public enum PlanSuccessStatus implements SuccessResponse {
 
+    PLAN_CREATED(HttpStatus.CREATED, "PLAN2001", "플랜이 생성되었습니다."),
+    PLAN_UPDATED(HttpStatus.OK, "PLAN2002", "플랜이 수정되었습니다."),
+    PLAN_COMPLETED(HttpStatus.OK, "PLAN2003", "아카이브에 플랜을 저장하였습니다."),
+    PLAN_PAUSED(HttpStatus.OK, "PLAN2004", "플랜이 중단되었습니다."),
+    PLAN_DELETED(HttpStatus.OK, "PLAN2005", "플랜이 삭제되었습니다."),
+
+    TODAY_PLAN_LIST_FOUND(HttpStatus.OK, "PLAN2006", "오늘의 플랜 목록을 성공적으로 조회하였습니다."),
+    PLAN_LIST_FOUND(HttpStatus.OK, "PLAN2007", "플랜 목록을 성공적으로 조회하였습니다."),
+    PLAN_FOUND(HttpStatus.OK, "PLAN2008", "플랜을 성공적으로 조회하였습니다."),
+
     ;
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/planit/planit/member/Member.java
+++ b/src/main/java/com/planit/planit/member/Member.java
@@ -6,6 +6,7 @@ import com.planit.planit.dream.Dream;
 import com.planit.planit.member.association.GuiltyFree;
 import com.planit.planit.member.association.Term;
 import com.planit.planit.member.enums.DailyCondition;
+import com.planit.planit.member.enums.GuiltyFreeReason;
 import com.planit.planit.member.enums.SignType;
 import com.planit.planit.plan.Plan;
 import com.planit.planit.task.Task;
@@ -44,13 +45,16 @@ public class Member extends BaseEntity {
     private DailyCondition dailyCondition;
 
     @Column
-    private LocalDateTime lastAttendanceDate;       // 마지막 출석일
+    private LocalDateTime lastAttendanceDate;           // 마지막 출석일
+
+    @Column
+    private Integer currentConsecutiveDays;             // 현재 연속일
 
     @Column(nullable = false)
-    private Integer consecutiveDays;                // 연속일 최고기록
+    private Integer maxConsecutiveDays;                 // 연속일 최고기록
 
     @Column(nullable = false)
-    private Integer perfectConsecutiveDays;         // 완벽 연속일
+    private Integer perfectConsecutiveDays;             // 완벽 연속일
 
     @Column
     private LocalDateTime inactive;
@@ -92,7 +96,8 @@ public class Member extends BaseEntity {
         this.signType = signType;
         this.guiltyFreeMode = guiltyFreeMode;
         this.dailyCondition = dailyCondition;
-        this.consecutiveDays = 0;
+        this.currentConsecutiveDays = 0;
+        this.maxConsecutiveDays = 0;
         this.perfectConsecutiveDays = 0;
         this.plans = new ArrayList<>();
         this.tasks = new ArrayList<>();

--- a/src/main/java/com/planit/planit/member/Member.java
+++ b/src/main/java/com/planit/planit/member/Member.java
@@ -44,6 +44,15 @@ public class Member extends BaseEntity {
     private DailyCondition dailyCondition;
 
     @Column
+    private LocalDateTime lastAttendanceDate;       // 마지막 출석일
+
+    @Column(nullable = false)
+    private Integer consecutiveDays;                // 연속일 최고기록
+
+    @Column(nullable = false)
+    private Integer perfectConsecutiveDays;         // 완벽 연속일
+
+    @Column
     private LocalDateTime inactive;
 
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -83,6 +92,8 @@ public class Member extends BaseEntity {
         this.signType = signType;
         this.guiltyFreeMode = guiltyFreeMode;
         this.dailyCondition = dailyCondition;
+        this.consecutiveDays = 0;
+        this.perfectConsecutiveDays = 0;
         this.plans = new ArrayList<>();
         this.tasks = new ArrayList<>();
         this.dreams = new ArrayList<>();

--- a/src/main/java/com/planit/planit/member/enums/GuiltyFreeReason.java
+++ b/src/main/java/com/planit/planit/member/enums/GuiltyFreeReason.java
@@ -1,9 +1,9 @@
 package com.planit.planit.member.enums;
 
 public enum GuiltyFreeReason {
-    PHYSICALLY_EXHAUSTED,     // 1. 육체적으로 힘들어요
-    NO_TIME_FOR_SCHEDULE,     // 2. 일정을 지킬 여유가 없어요
-    LACK_OF_MOTIVATION,       // 3. 의욕이 없어요
-    UNWILLING_TO_EXPRESS,     // 4. 별로 표현하고 싶지 않아요
-    SKIP                      // 5. 건너뛰기
+    PHYSICALLY_EXHAUSTED,     // 1. 손에 안 잡혀요
+    PLAN_FAILED,              // 2. 계획대로 안 돼요
+    NO_TIME_FOR_SCHEDULE,     // 3. 할 일이 많았어요
+    LACK_OF_MOTIVATION,       // 4. 너무 지쳐버렸어요
+    NONE                      // 5. 초기값
 }

--- a/src/main/java/com/planit/planit/plan/Plan.java
+++ b/src/main/java/com/planit/planit/plan/Plan.java
@@ -10,6 +10,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,10 +38,10 @@ public class Plan extends BaseEntity {
     private PlanStatus planStatus;      // 플랜 진행 여부
 
     @Column
-    private LocalDateTime startedAt;    // 플랜 시작일
+    private LocalDate startedAt;    // 플랜 시작일
 
     @Column
-    private LocalDateTime finishedAt;   // 플랜 종료일
+    private LocalDate finishedAt;   // 플랜 종료일
 
     @Column
     private LocalDateTime inactive;     // 플랜 비활성화(중단, 아카이빙, 삭제)
@@ -65,8 +66,8 @@ public class Plan extends BaseEntity {
             String motivation,
             String icon,
             PlanStatus planStatus,
-            LocalDateTime startedAt,
-            LocalDateTime finishedAt,
+            LocalDate startedAt,
+            LocalDate finishedAt,
             Member member
 
     ) {
@@ -85,7 +86,7 @@ public class Plan extends BaseEntity {
 
     public void updatePlan(
             String title,          String motivation,       String icon,
-            PlanStatus planStatus, LocalDateTime startedAt, LocalDateTime finishedAt
+            PlanStatus planStatus, LocalDate startedAt,     LocalDate finishedAt
     ) {
         this.title = title;
         this.motivation = motivation;

--- a/src/main/java/com/planit/planit/plan/Plan.java
+++ b/src/main/java/com/planit/planit/plan/Plan.java
@@ -112,4 +112,8 @@ public class Plan extends BaseEntity {
     }
 
     public int countTasks() { return this.tasks.size(); }
+
+    public void addTask(Task task) {
+        tasks.add(task);
+    }
 }

--- a/src/main/java/com/planit/planit/plan/service/PlanCommandService.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanCommandService.java
@@ -11,7 +11,7 @@ public interface PlanCommandService {
     // 플랜 수정하기
     PlanResponseDTO.PlanMetaDTO updatePlan(Long memberId, Long planId, PlanRequestDTO.PlanDTO planDTO);
 
-    // 플랜 완료 처리하기
+    // 플랜 완료(아카이빙) 하기
     PlanResponseDTO.PlanMetaDTO completePlan(Long memberId, Long planId);
 
     // 플랜 중단하기

--- a/src/main/java/com/planit/planit/plan/service/PlanCommandService.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanCommandService.java
@@ -6,17 +6,17 @@ import com.planit.planit.web.dto.plan.PlanResponseDTO;
 public interface PlanCommandService {
 
     // 플랜 생성하기
-    PlanResponseDTO.PlanMetaDTO createPlan(PlanRequestDTO.PlanDTO planDTO);
+    PlanResponseDTO.PlanMetaDTO createPlan(Long memberId, PlanRequestDTO.PlanDTO planDTO);
 
     // 플랜 수정하기
-    PlanResponseDTO.PlanMetaDTO updatePlan(Long planId, PlanRequestDTO.PlanDTO planDTO);
+    PlanResponseDTO.PlanMetaDTO updatePlan(Long memberId, Long planId, PlanRequestDTO.PlanDTO planDTO);
 
     // 플랜 완료 처리하기
-    PlanResponseDTO.PlanMetaDTO completePlan(Long planId);
+    PlanResponseDTO.PlanMetaDTO completePlan(Long memberId, Long planId);
 
     // 플랜 중단하기
-    PlanResponseDTO.PlanMetaDTO pausePlan(Long planId);
+    PlanResponseDTO.PlanMetaDTO pausePlan(Long memberId, Long planId);
 
     // 플랜 삭제하기
-    PlanResponseDTO.PlanMetaDTO deletePlan(Long planId);
+    PlanResponseDTO.PlanMetaDTO deletePlan(Long memberId, Long planId);
 }

--- a/src/main/java/com/planit/planit/plan/service/PlanCommandServiceImpl.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanCommandServiceImpl.java
@@ -2,6 +2,8 @@ package com.planit.planit.plan.service;
 
 import com.planit.planit.common.api.member.MemberHandler;
 import com.planit.planit.common.api.member.status.MemberErrorStatus;
+import com.planit.planit.common.api.plan.PlanHandler;
+import com.planit.planit.common.api.plan.status.PlanErrorStatus;
 import com.planit.planit.member.Member;
 import com.planit.planit.member.MemberRepository;
 import com.planit.planit.plan.Plan;
@@ -45,7 +47,25 @@ public class PlanCommandServiceImpl implements PlanCommandService {
 
     @Override
     public PlanResponseDTO.PlanMetaDTO updatePlan(Long memberId, Long planId, PlanRequestDTO.PlanDTO planDTO) {
-        return null;
+
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new PlanHandler(PlanErrorStatus.PLAN_NOT_FOUND));
+
+        plan.updatePlan(
+                planDTO.getTitle(),
+                planDTO.getMotivation(),
+                planDTO.getIcon(),
+                planDTO.getPlanStatus(),
+                planDTO.getStartedAt(),
+                planDTO.getFinishedAt()
+        );
+
+        planRepository.save(plan);
+
+        return PlanConverter.toPlanMetaDTO(plan);
     }
 
     @Override

--- a/src/main/java/com/planit/planit/plan/service/PlanCommandServiceImpl.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanCommandServiceImpl.java
@@ -24,6 +24,7 @@ public class PlanCommandServiceImpl implements PlanCommandService {
     private final MemberRepository memberRepository;
     private final PlanRepository planRepository;
 
+
     @Override
     public PlanResponseDTO.PlanMetaDTO createPlan(Long memberId, PlanRequestDTO.PlanDTO planDTO) {
 
@@ -45,11 +46,9 @@ public class PlanCommandServiceImpl implements PlanCommandService {
         return PlanConverter.toPlanMetaDTO(plan);
     }
 
+
     @Override
     public PlanResponseDTO.PlanMetaDTO updatePlan(Long memberId, Long planId, PlanRequestDTO.PlanDTO planDTO) {
-
-        memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
 
         Plan plan = planRepository.findById(planId)
                 .orElseThrow(() -> new PlanHandler(PlanErrorStatus.PLAN_NOT_FOUND));
@@ -73,14 +72,22 @@ public class PlanCommandServiceImpl implements PlanCommandService {
         return PlanConverter.toPlanMetaDTO(plan);
     }
 
+
     @Override
     public PlanResponseDTO.PlanMetaDTO completePlan(Long memberId, Long planId) {
 
-        memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new PlanHandler(PlanErrorStatus.PLAN_NOT_FOUND));
 
+        // 로그인한 회원의 플랜인지 확인
+        if (!memberId.equals(plan.getMember().getId())) {
+            throw new PlanHandler(PlanErrorStatus.MEMBER_PLAN_NOT_FOUND);
+        }
 
-        return null;
+        plan.completePlan();
+        planRepository.save(plan);
+
+        return PlanConverter.toPlanMetaDTO(plan);
     }
 
     @Override

--- a/src/main/java/com/planit/planit/plan/service/PlanCommandServiceImpl.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanCommandServiceImpl.java
@@ -92,7 +92,19 @@ public class PlanCommandServiceImpl implements PlanCommandService {
 
     @Override
     public PlanResponseDTO.PlanMetaDTO pausePlan(Long memberId, Long planId) {
-        return null;
+
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new PlanHandler(PlanErrorStatus.PLAN_NOT_FOUND));
+
+        // 로그인한 회원의 플랜인지 확인
+        if (!memberId.equals(plan.getMember().getId())) {
+            throw new PlanHandler(PlanErrorStatus.MEMBER_PLAN_NOT_FOUND);
+        }
+
+        plan.pausePlan();
+        planRepository.save(plan);
+
+        return PlanConverter.toPlanMetaDTO(plan);
     }
 
     @Override

--- a/src/main/java/com/planit/planit/plan/service/PlanCommandServiceImpl.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanCommandServiceImpl.java
@@ -54,6 +54,11 @@ public class PlanCommandServiceImpl implements PlanCommandService {
         Plan plan = planRepository.findById(planId)
                 .orElseThrow(() -> new PlanHandler(PlanErrorStatus.PLAN_NOT_FOUND));
 
+        // 로그인한 회원의 플랜인지 확인
+        if (!memberId.equals(plan.getMember().getId())) {
+            throw new PlanHandler(PlanErrorStatus.MEMBER_PLAN_NOT_FOUND);
+        }
+
         plan.updatePlan(
                 planDTO.getTitle(),
                 planDTO.getMotivation(),
@@ -70,6 +75,11 @@ public class PlanCommandServiceImpl implements PlanCommandService {
 
     @Override
     public PlanResponseDTO.PlanMetaDTO completePlan(Long memberId, Long planId) {
+
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+
         return null;
     }
 

--- a/src/main/java/com/planit/planit/plan/service/PlanCommandServiceImpl.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanCommandServiceImpl.java
@@ -1,34 +1,65 @@
 package com.planit.planit.plan.service;
 
+import com.planit.planit.common.api.member.MemberHandler;
+import com.planit.planit.common.api.member.status.MemberErrorStatus;
+import com.planit.planit.member.Member;
+import com.planit.planit.member.MemberRepository;
+import com.planit.planit.plan.Plan;
+import com.planit.planit.plan.enums.PlanStatus;
+import com.planit.planit.plan.repository.PlanRepository;
 import com.planit.planit.web.dto.plan.PlanRequestDTO;
 import com.planit.planit.web.dto.plan.PlanResponseDTO;
+import com.planit.planit.web.dto.plan.converter.PlanConverter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class PlanCommandServiceImpl implements PlanCommandService {
 
+    private final MemberRepository memberRepository;
+    private final PlanRepository planRepository;
+
     @Override
-    public PlanResponseDTO.PlanMetaDTO createPlan(PlanRequestDTO.PlanDTO planDTO) {
+    public PlanResponseDTO.PlanMetaDTO createPlan(Long memberId, PlanRequestDTO.PlanDTO planDTO) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        Plan plan = Plan.builder()
+                .title(planDTO.getTitle())
+                .motivation(planDTO.getMotivation())
+                .icon(planDTO.getIcon())
+                .planStatus(PlanStatus.IN_PROGRESS)
+                .startedAt(planDTO.getStartedAt())
+                .finishedAt(planDTO.getFinishedAt())
+                .member(member)
+                .build();
+
+        plan = planRepository.save(plan);
+
+        return PlanConverter.toPlanMetaDTO(plan);
+    }
+
+    @Override
+    public PlanResponseDTO.PlanMetaDTO updatePlan(Long memberId, Long planId, PlanRequestDTO.PlanDTO planDTO) {
         return null;
     }
 
     @Override
-    public PlanResponseDTO.PlanMetaDTO updatePlan(Long planId, PlanRequestDTO.PlanDTO planDTO) {
+    public PlanResponseDTO.PlanMetaDTO completePlan(Long memberId, Long planId) {
         return null;
     }
 
     @Override
-    public PlanResponseDTO.PlanMetaDTO completePlan(Long planId) {
+    public PlanResponseDTO.PlanMetaDTO pausePlan(Long memberId, Long planId) {
         return null;
     }
 
     @Override
-    public PlanResponseDTO.PlanMetaDTO pausePlan(Long planId) {
-        return null;
-    }
-
-    @Override
-    public PlanResponseDTO.PlanMetaDTO deletePlan(Long planId) {
+    public PlanResponseDTO.PlanMetaDTO deletePlan(Long memberId, Long planId) {
         return null;
     }
 }

--- a/src/main/java/com/planit/planit/plan/service/PlanCommandServiceImpl.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanCommandServiceImpl.java
@@ -90,6 +90,7 @@ public class PlanCommandServiceImpl implements PlanCommandService {
         return PlanConverter.toPlanMetaDTO(plan);
     }
 
+
     @Override
     public PlanResponseDTO.PlanMetaDTO pausePlan(Long memberId, Long planId) {
 
@@ -107,8 +108,21 @@ public class PlanCommandServiceImpl implements PlanCommandService {
         return PlanConverter.toPlanMetaDTO(plan);
     }
 
+
     @Override
     public PlanResponseDTO.PlanMetaDTO deletePlan(Long memberId, Long planId) {
-        return null;
+
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new PlanHandler(PlanErrorStatus.PLAN_NOT_FOUND));
+
+        // 로그인한 회원의 플랜인지 확인
+        if (!memberId.equals(plan.getMember().getId())) {
+            throw new PlanHandler(PlanErrorStatus.MEMBER_PLAN_NOT_FOUND);
+        }
+
+        plan.deletePlan();
+        planRepository.save(plan);
+
+        return PlanConverter.toPlanMetaDTO(plan);
     }
 }

--- a/src/main/java/com/planit/planit/plan/service/PlanQueryService.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanQueryService.java
@@ -5,9 +5,13 @@ import com.planit.planit.web.dto.plan.PlanResponseDTO;
 
 public interface PlanQueryService {
 
+    // 오늘의 플랜 목록 조회하기
+    PlanResponseDTO.TodayPlanListDTO getTodayPlans(Long memberId);
+
     // 플랜 단건 조회하기
-    PlanResponseDTO.PlanContentDTO getPlan(Long planId);
+    PlanResponseDTO.PlanContentDTO getPlan(Long memberId, Long planId);
 
     // 플랜 목록 조회하기
-    PlanResponseDTO.PlanListDTO getPlansByPlanStatus(PlanStatus planStatus);
+    PlanResponseDTO.PlanListDTO getPlansByPlanStatus(Long memberId, PlanStatus planStatus);
+
 }

--- a/src/main/java/com/planit/planit/plan/service/PlanQueryServiceImpl.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanQueryServiceImpl.java
@@ -4,7 +4,6 @@ import com.planit.planit.common.api.member.MemberHandler;
 import com.planit.planit.common.api.member.status.MemberErrorStatus;
 import com.planit.planit.common.api.plan.PlanHandler;
 import com.planit.planit.common.api.plan.status.PlanErrorStatus;
-import com.planit.planit.member.Member;
 import com.planit.planit.member.MemberRepository;
 import com.planit.planit.plan.Plan;
 import com.planit.planit.plan.enums.PlanStatus;
@@ -60,6 +59,11 @@ public class PlanQueryServiceImpl implements PlanQueryService {
 
     @Override
     public PlanResponseDTO.PlanListDTO getPlansByPlanStatus(Long memberId, PlanStatus planStatus) {
-        return null;
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        List<Plan> plans = planRepository.findAllByMemberIdAndPlanStatus(memberId, planStatus);
+
+        return PlanConverter.toPlanListDTO(planStatus, plans);
     }
 }

--- a/src/main/java/com/planit/planit/plan/service/PlanQueryServiceImpl.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanQueryServiceImpl.java
@@ -2,6 +2,9 @@ package com.planit.planit.plan.service;
 
 import com.planit.planit.common.api.member.MemberHandler;
 import com.planit.planit.common.api.member.status.MemberErrorStatus;
+import com.planit.planit.common.api.plan.PlanHandler;
+import com.planit.planit.common.api.plan.status.PlanErrorStatus;
+import com.planit.planit.member.Member;
 import com.planit.planit.member.MemberRepository;
 import com.planit.planit.plan.Plan;
 import com.planit.planit.plan.enums.PlanStatus;
@@ -40,7 +43,19 @@ public class PlanQueryServiceImpl implements PlanQueryService {
 
     @Override
     public PlanResponseDTO.PlanContentDTO getPlan(Long memberId, Long planId) {
-        return null;
+
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        Plan plan = planRepository.findById(planId)
+            .orElseThrow(() -> new PlanHandler(PlanErrorStatus.PLAN_NOT_FOUND));
+
+        // 로그인한 회원의 plan인지 확인
+        if (!memberId.equals(plan.getMember().getId())) {
+            throw new PlanHandler(PlanErrorStatus.MEMBER_PLAN_NOT_FOUND);
+        }
+
+        return PlanConverter.toPlanContentDTO(plan);
     }
 
     @Override

--- a/src/main/java/com/planit/planit/plan/service/PlanQueryServiceImpl.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanQueryServiceImpl.java
@@ -51,7 +51,7 @@ public class PlanQueryServiceImpl implements PlanQueryService {
         Plan plan = planRepository.findById(planId)
             .orElseThrow(() -> new PlanHandler(PlanErrorStatus.PLAN_NOT_FOUND));
 
-        // 로그인한 회원의 plan인지 확인
+        // 로그인한 회원의 플랜인지 확인
         if (!memberId.equals(plan.getMember().getId())) {
             throw new PlanHandler(PlanErrorStatus.MEMBER_PLAN_NOT_FOUND);
         }

--- a/src/main/java/com/planit/planit/plan/service/PlanQueryServiceImpl.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanQueryServiceImpl.java
@@ -12,11 +12,13 @@ import com.planit.planit.web.dto.plan.PlanResponseDTO;
 import com.planit.planit.web.dto.plan.converter.PlanConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class PlanQueryServiceImpl implements PlanQueryService {
 

--- a/src/main/java/com/planit/planit/plan/service/PlanQueryServiceImpl.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanQueryServiceImpl.java
@@ -1,19 +1,50 @@
 package com.planit.planit.plan.service;
 
+import com.planit.planit.common.api.member.MemberHandler;
+import com.planit.planit.common.api.member.status.MemberErrorStatus;
+import com.planit.planit.member.MemberRepository;
+import com.planit.planit.plan.Plan;
 import com.planit.planit.plan.enums.PlanStatus;
+import com.planit.planit.plan.repository.PlanRepository;
 import com.planit.planit.web.dto.plan.PlanResponseDTO;
+import com.planit.planit.web.dto.plan.converter.PlanConverter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Service
+@RequiredArgsConstructor
 public class PlanQueryServiceImpl implements PlanQueryService {
 
+    private final MemberRepository memberRepository;
+    private final PlanRepository planRepository;
+
     @Override
-    public PlanResponseDTO.PlanContentDTO getPlan(Long planId) {
+    public PlanResponseDTO.TodayPlanListDTO getTodayPlans(Long memberId) {
+
+        LocalDate todayDate = LocalDate.now();
+
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        List<Plan> todayPlans = planRepository
+                .findAllByMemberIdAndPlanStatus(memberId, PlanStatus.IN_PROGRESS).stream()
+                .filter(plan -> plan.getFinishedAt().isAfter(todayDate) ||
+                                     plan.getFinishedAt().isEqual(todayDate))
+                .toList();
+
+        return PlanConverter.toTodayPlanListDTO(todayDate, todayPlans);
+    }
+
+    @Override
+    public PlanResponseDTO.PlanContentDTO getPlan(Long memberId, Long planId) {
         return null;
     }
 
     @Override
-    public PlanResponseDTO.PlanListDTO getPlansByPlanStatus(PlanStatus planStatus) {
+    public PlanResponseDTO.PlanListDTO getPlansByPlanStatus(Long memberId, PlanStatus planStatus) {
         return null;
     }
 }

--- a/src/main/java/com/planit/planit/task/Task.java
+++ b/src/main/java/com/planit/planit/task/Task.java
@@ -5,6 +5,7 @@ import com.planit.planit.common.entity.BaseEntity;
 import com.planit.planit.member.Member;
 import com.planit.planit.plan.Plan;
 import com.planit.planit.task.enums.RoutineDay;
+import com.planit.planit.task.enums.TaskType;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -35,11 +36,9 @@ public class Task extends BaseEntity {
     @Column
     private LocalTime routineTime;
 
-    @Column(nullable = false, length = 30)
-    private String taskForWellBeing;
-
-    @Column(nullable = false, length = 30)
-    private String taskForDistress;
+    @Enumerated(EnumType.STRING)
+    @Column
+    private TaskType taskType;
 
     @Column(nullable = false, length = 30)
     private Boolean isCompleted;
@@ -69,8 +68,7 @@ public class Task extends BaseEntity {
             Long id,
             String title,
             Boolean isRoutine,
-            String taskForWellBeing,
-            String taskForDistress,
+            TaskType taskType,
             Member member,
             @Nullable Plan plan,
             @Nullable RoutineDay routineDay,
@@ -79,8 +77,7 @@ public class Task extends BaseEntity {
         this.id = id;
         this.title = title;
         this.isRoutine = isRoutine;
-        this.taskForWellBeing = taskForWellBeing;
-        this.taskForDistress = taskForDistress;
+        this.taskType = taskType;
         this.isCompleted = false;
         this.member = member;
         this.plan = plan;

--- a/src/main/java/com/planit/planit/task/enums/TaskType.java
+++ b/src/main/java/com/planit/planit/task/enums/TaskType.java
@@ -1,0 +1,5 @@
+package com.planit.planit.task.enums;
+
+public enum TaskType {
+    ALL, SLOW, PASSIONATE
+}

--- a/src/main/java/com/planit/planit/web/controller/PlanController.java
+++ b/src/main/java/com/planit/planit/web/controller/PlanController.java
@@ -1,0 +1,108 @@
+package com.planit.planit.web.controller;
+
+import com.planit.planit.common.api.ApiResponse;
+import com.planit.planit.common.api.plan.status.PlanSuccessStatus;
+import com.planit.planit.plan.enums.PlanStatus;
+import com.planit.planit.plan.service.PlanCommandService;
+import com.planit.planit.plan.service.PlanQueryService;
+import com.planit.planit.web.dto.plan.PlanRequestDTO;
+import com.planit.planit.web.dto.plan.PlanResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/planit")
+@Tag(name = "PLAN", description = "플랜 관련 API")
+public class PlanController {
+
+    private final PlanQueryService planQueryService;
+    private final PlanCommandService planCommandService;
+
+    @Operation(summary = "[PLAN] 플랜 생성하기")
+    @PostMapping("/plans")
+    public ApiResponse<PlanResponseDTO.PlanMetaDTO> createPlan(
+            @RequestBody PlanRequestDTO.PlanDTO planDTO
+    ) {
+        Long memberId = 1L; // 인증 기능 구현 이후 변경
+        PlanResponseDTO.PlanMetaDTO planMetaDTO = planCommandService.createPlan(memberId, planDTO);
+        return ApiResponse.onSuccess(PlanSuccessStatus.PLAN_CREATED, planMetaDTO);
+    }
+
+
+    @Operation(summary = "[PLAN] 플랜 수정하기")
+    @PatchMapping("/plans/{planId}")
+    public ApiResponse<PlanResponseDTO.PlanMetaDTO> updatePlan(
+            @PathVariable Long planId,
+            @RequestBody PlanRequestDTO.PlanDTO planDTO
+    ) {
+        Long memberId = 1L; // 인증 기능 구현 이후 변경
+        PlanResponseDTO.PlanMetaDTO planMetaDTO = planCommandService.updatePlan(memberId, planId, planDTO);
+        return ApiResponse.onSuccess(PlanSuccessStatus.PLAN_UPDATED, planMetaDTO);
+    }
+
+
+    @Operation(summary = "[PLAN] 플랜 완료(아카이빙) 하기")
+    @PatchMapping("/plans/{planId}/complete")
+    public ApiResponse<PlanResponseDTO.PlanMetaDTO> completePlan(
+            @PathVariable Long planId
+    ) {
+        Long memberId = 1L; // 인증 기능 구현 이후 변경
+        PlanResponseDTO.PlanMetaDTO planMetaDTO = planCommandService.completePlan(memberId, planId);
+        return ApiResponse.onSuccess(PlanSuccessStatus.PLAN_COMPLETED, planMetaDTO);
+    }
+
+
+    @Operation(summary = "[PLAN] 플랜 중단하기")
+    @PatchMapping("/plans/{planId}/pause")
+    public ApiResponse<PlanResponseDTO.PlanMetaDTO> pausePlan(
+            @PathVariable Long planId
+    ) {
+        Long memberId = 1L; // 인증 기능 구현 이후 변경
+        PlanResponseDTO.PlanMetaDTO planMetaDTO = planCommandService.pausePlan(memberId, planId);
+        return ApiResponse.onSuccess(PlanSuccessStatus.PLAN_PAUSED, planMetaDTO);
+    }
+
+
+    @Operation(summary = "[PLAN] 플랜 삭제하기")
+    @PatchMapping("/plans/{planId}/delete")
+    public ApiResponse<PlanResponseDTO.PlanMetaDTO> deletePlan(
+            @PathVariable Long planId
+    ) {
+        Long memberId = 1L; // 인증 기능 구현 이후 변경
+        PlanResponseDTO.PlanMetaDTO planMetaDTO = planCommandService.deletePlan(memberId, planId);
+        return ApiResponse.onSuccess(PlanSuccessStatus.PLAN_DELETED, planMetaDTO);
+    }
+
+
+    @Operation(summary = "[PLAN] 오늘의 플랜 목록 조회하기")
+    @GetMapping("/plans/today")
+    public ApiResponse<PlanResponseDTO.TodayPlanListDTO> getTodayPlans() {
+        Long memberId = 1L; // 인증 기능 구현 이후 변경
+        PlanResponseDTO.TodayPlanListDTO todayPlanListDTO = planQueryService.getTodayPlans(memberId);
+        return ApiResponse.onSuccess(PlanSuccessStatus.TODAY_PLAN_LIST_FOUND, todayPlanListDTO);
+    }
+
+
+    @Operation(summary = "[PLAN] 플랜 목록 조회하기")
+    @GetMapping("/plans")
+    public ApiResponse<PlanResponseDTO.PlanListDTO> getTodayPlans(
+            @RequestParam PlanStatus planStatus
+    ) {
+        Long memberId = 1L; // 인증 기능 구현 이후 변경
+        PlanResponseDTO.PlanListDTO planListDTO = planQueryService.getPlansByPlanStatus(memberId, planStatus);
+        return ApiResponse.onSuccess(PlanSuccessStatus.PLAN_LIST_FOUND, planListDTO);
+    }
+
+    @Operation(summary = "[PLAN] 플랜 단건 조회하기")
+    @GetMapping("/plans/{planId}")
+    public ApiResponse<PlanResponseDTO.PlanContentDTO> getPlan(
+            @PathVariable Long planId
+    ) {
+        Long memberId = 1L; // 인증 기능 구현 이후 변경
+        PlanResponseDTO.PlanContentDTO planContentDTO = planQueryService.getPlan(memberId, planId);
+        return ApiResponse.onSuccess(PlanSuccessStatus.PLAN_FOUND, planContentDTO);
+    }
+}

--- a/src/main/java/com/planit/planit/web/dto/plan/PlanRequestDTO.java
+++ b/src/main/java/com/planit/planit/web/dto/plan/PlanRequestDTO.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 public class PlanRequestDTO {
@@ -19,7 +19,7 @@ public class PlanRequestDTO {
         private final String motivation;
         private final String icon;
         private final PlanStatus planStatus;
-        private final LocalDateTime startedAt;
-        private final LocalDateTime finishedAt;
+        private final LocalDate startedAt;
+        private final LocalDate finishedAt;
     }
 }

--- a/src/main/java/com/planit/planit/web/dto/plan/PlanResponseDTO.java
+++ b/src/main/java/com/planit/planit/web/dto/plan/PlanResponseDTO.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -39,14 +40,33 @@ public class PlanResponseDTO {
     @Getter
     @Builder
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class TodayPlanDTO {
+        private final Long planId;
+        private final String title;
+        private final String dDay;
+        private final List<TaskPreviewDTO> tasks;
+    }
+
+    @Getter
+    @Builder
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     public static class PlanMetaDTO {
         private final Long planId;
         private final String title;
         private final String icon;
         private final String motivation;
         private final PlanStatus planStatus;
-        private final LocalDateTime startedAt;
-        private final LocalDateTime finishedAt;
+        private final LocalDate startedAt;
+        private final LocalDate finishedAt;
+    }
+
+    @Getter
+    @Builder
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class TodayPlanListDTO {
+        private final LocalDate todayDate;
+        private final List<TodayPlanDTO> plans;
+
     }
 
     @Getter

--- a/src/main/java/com/planit/planit/web/dto/plan/converter/PlanConverter.java
+++ b/src/main/java/com/planit/planit/web/dto/plan/converter/PlanConverter.java
@@ -34,7 +34,7 @@ public class PlanConverter {
                 .build();
     }
 
-    public static PlanResponseDTO.PlanContentDTO toPlanDetailDTO(Plan plan) {
+    public static PlanResponseDTO.PlanContentDTO toPlanContentDTO(Plan plan) {
         return PlanResponseDTO.PlanContentDTO.builder()
                 .planId(plan.getId())
                 .title(plan.getTitle())

--- a/src/main/java/com/planit/planit/web/dto/plan/converter/PlanConverter.java
+++ b/src/main/java/com/planit/planit/web/dto/plan/converter/PlanConverter.java
@@ -29,6 +29,7 @@ public class PlanConverter {
                 .planId(plan.getId())
                 .title(plan.getTitle())
                 .icon(plan.getIcon())
+                .motivation(plan.getMotivation())
                 .totalTasks(plan.countTasks())
                 .dDay(dDay)
                 .build();

--- a/src/main/java/com/planit/planit/web/dto/plan/converter/PlanConverter.java
+++ b/src/main/java/com/planit/planit/web/dto/plan/converter/PlanConverter.java
@@ -6,7 +6,7 @@ import com.planit.planit.web.dto.plan.PlanRequestDTO;
 import com.planit.planit.web.dto.plan.PlanResponseDTO;
 import com.planit.planit.web.dto.task.converter.TaskConverter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
@@ -24,7 +24,7 @@ public class PlanConverter {
     }
 
     public static PlanResponseDTO.PlanPreviewDTO toPlanPreviewDTO(Plan plan) {
-        String dDay = formatDDay(LocalDateTime.now(), plan.getFinishedAt());
+        String dDay = formatDDay(LocalDate.now(), plan.getFinishedAt());
         return PlanResponseDTO.PlanPreviewDTO.builder()
                 .planId(plan.getId())
                 .title(plan.getTitle())
@@ -46,6 +46,18 @@ public class PlanConverter {
                 .build();
     }
 
+    public static PlanResponseDTO.TodayPlanDTO toTodayPlanDTO(Plan plan) {
+        String dDay = formatDDay(LocalDate.now(), plan.getFinishedAt());
+        return PlanResponseDTO.TodayPlanDTO.builder()
+                .planId(plan.getId())
+                .title(plan.getTitle())
+                .dDay(dDay)
+                .tasks(plan.getTasks().stream()
+                        .map(TaskConverter::toTaskPreviewDTO)
+                        .toList())
+                .build();
+    }
+
     public static PlanResponseDTO.PlanMetaDTO toPlanMetaDTO(Plan plan) {
         return PlanResponseDTO.PlanMetaDTO.builder()
                 .planId(plan.getId())
@@ -58,6 +70,15 @@ public class PlanConverter {
                 .build();
     }
 
+    public static PlanResponseDTO.TodayPlanListDTO toTodayPlanListDTO(LocalDate todayDate, List<Plan> plans) {
+        return PlanResponseDTO.TodayPlanListDTO.builder()
+                .todayDate(todayDate)
+                .plans(plans.stream()
+                        .map(PlanConverter::toTodayPlanDTO)
+                        .toList())
+                .build();
+    }
+
     public static PlanResponseDTO.PlanListDTO toPlanListDTO(PlanStatus planStatus, List<Plan> plans) {
         return PlanResponseDTO.PlanListDTO.builder()
                 .planStatus(planStatus)
@@ -67,12 +88,15 @@ public class PlanConverter {
                 .build();
     }
 
-    private static String formatDDay(LocalDateTime startedAt, LocalDateTime finishedAt) {
+    private static String formatDDay(LocalDate startedAt, LocalDate finishedAt) {
         Long day = ChronoUnit.DAYS.between(startedAt, finishedAt);
         if (startedAt.isAfter(finishedAt)) {
             return String.format("D+%d", -day);
-        } else {
+        } else if (startedAt.isBefore(finishedAt)) {
             return String.format("D-%d", day);
+        }
+        else {
+            return "D-Day";
         }
     }
 }

--- a/src/main/java/com/planit/planit/web/dto/task/TaskResponseDTO.java
+++ b/src/main/java/com/planit/planit/web/dto/task/TaskResponseDTO.java
@@ -1,22 +1,21 @@
 package com.planit.planit.web.dto.task;
 
+import com.planit.planit.task.enums.TaskType;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 public class TaskResponseDTO {
 
     @Getter
+    @Builder
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     public static class TaskPreviewDTO {
         private final Long taskId;
+        private final TaskType taskType;
         private final String title;
         private final Boolean isCompleted;
-
-        @Builder
-        public TaskPreviewDTO(Long taskId, String title, Boolean isCompleted) {
-            this.taskId = taskId;
-            this.title = title;
-            this.isCompleted = isCompleted;
-        }
     }
 }

--- a/src/main/java/com/planit/planit/web/dto/task/converter/TaskConverter.java
+++ b/src/main/java/com/planit/planit/web/dto/task/converter/TaskConverter.java
@@ -8,6 +8,7 @@ public class TaskConverter {
     public static TaskResponseDTO.TaskPreviewDTO toTaskPreviewDTO(Task task) {
         return TaskResponseDTO.TaskPreviewDTO.builder()
                 .taskId(task.getId())
+                .taskType(task.getTaskType())
                 .title(task.getTitle())
                 .isCompleted(task.getIsCompleted())
                 .build();

--- a/src/test/java/com/planit/planit/plan/PlanRepositoryTest.java
+++ b/src/test/java/com/planit/planit/plan/PlanRepositoryTest.java
@@ -10,7 +10,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,7 +69,7 @@ class PlanRepositoryTest {
                 .motivation("다짐문장")
                 .icon("아이콘")
                 .planStatus(PlanStatus.PAUSED)
-                .finishedAt(LocalDateTime.now())
+                .finishedAt(LocalDate.now())
                 .member(member)
                 .build();
         pausedPlan2 = Plan.builder()
@@ -77,7 +77,7 @@ class PlanRepositoryTest {
                 .motivation("다짐문장")
                 .icon("아이콘")
                 .planStatus(PlanStatus.PAUSED)
-                .finishedAt(LocalDateTime.now().plusDays(1))
+                .finishedAt(LocalDate.now().plusDays(1))
                 .member(member)
                 .build();
         archivedPlan1 = Plan.builder()
@@ -85,7 +85,7 @@ class PlanRepositoryTest {
                 .motivation("다짐문장")
                 .icon("아이콘")
                 .planStatus(PlanStatus.ARCHIVED)
-                .finishedAt(LocalDateTime.now())
+                .finishedAt(LocalDate.now())
                 .member(member)
                 .build();
         archivedPlan2 = Plan.builder()
@@ -93,7 +93,7 @@ class PlanRepositoryTest {
                 .motivation("다짐문장")
                 .icon("아이콘")
                 .planStatus(PlanStatus.ARCHIVED)
-                .finishedAt(LocalDateTime.now().plusDays(1))
+                .finishedAt(LocalDate.now().plusDays(1))
                 .member(member)
                 .build();
     }
@@ -153,8 +153,8 @@ class PlanRepositoryTest {
 
         // then
         assertThat(result.size()).isEqualTo(2);
-        assertThat(result.get(0).getTitle()).isEqualTo("2");
-        assertThat(result.get(1).getTitle()).isEqualTo("1");
+        assertThat(result.get(0).getTitle()).isEqualTo("1");
+        assertThat(result.get(1).getTitle()).isEqualTo("2");
     }
 
     @Test
@@ -173,8 +173,8 @@ class PlanRepositoryTest {
 
         // then
         assertThat(result.size()).isEqualTo(2);
-        assertThat(result.get(0).getTitle()).isEqualTo("4");
-        assertThat(result.get(1).getTitle()).isEqualTo("3");
+        assertThat(result.get(0).getTitle()).isEqualTo("3");
+        assertThat(result.get(1).getTitle()).isEqualTo("4");
     }
 
     @Test
@@ -193,8 +193,8 @@ class PlanRepositoryTest {
 
         // then
         assertThat(result.size()).isEqualTo(2);
-        assertThat(result.get(0).getTitle()).isEqualTo("6");
-        assertThat(result.get(1).getTitle()).isEqualTo("5");
+        assertThat(result.get(0).getTitle()).isEqualTo("5");
+        assertThat(result.get(1).getTitle()).isEqualTo("6");
     }
 
     @Test

--- a/src/test/java/com/planit/planit/plan/service/PlanCommandServiceTest.java
+++ b/src/test/java/com/planit/planit/plan/service/PlanCommandServiceTest.java
@@ -18,7 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -73,8 +73,8 @@ class PlanCommandServiceTest {
                 .motivation("목표")
                 .icon("아이콘")
                 .planStatus(PlanStatus.IN_PROGRESS)
-                .startedAt(LocalDateTime.now())
-                .finishedAt(LocalDateTime.now().plusMonths(1))
+                .startedAt(LocalDate.now())
+                .finishedAt(LocalDate.now().plusMonths(1))
                 .build();
 
         plan = Plan.builder()
@@ -113,8 +113,8 @@ class PlanCommandServiceTest {
                 .motivation("목표")
                 .icon("아이콘")
                 .planStatus(PlanStatus.IN_PROGRESS)
-                .startedAt(LocalDateTime.now())
-                .finishedAt(LocalDateTime.now().plusMonths(1))
+                .startedAt(LocalDate.now())
+                .finishedAt(LocalDate.now().plusMonths(1))
                 .build();
 
         plan = Plan.builder()
@@ -151,8 +151,8 @@ class PlanCommandServiceTest {
                 .motivation("목표")
                 .icon("아이콘")
                 .planStatus(PlanStatus.IN_PROGRESS)
-                .startedAt(LocalDateTime.now())
-                .finishedAt(LocalDateTime.now().plusMonths(1))
+                .startedAt(LocalDate.now())
+                .finishedAt(LocalDate.now().plusMonths(1))
                 .build();
 
         when(planRepository.findById(1L)).thenReturn(Optional.empty());
@@ -176,8 +176,8 @@ class PlanCommandServiceTest {
                 .motivation("목표")
                 .icon("아이콘")
                 .planStatus(PlanStatus.ARCHIVED)
-                .startedAt(LocalDateTime.now())
-                .finishedAt(LocalDateTime.now().plusMonths(1))
+                .startedAt(LocalDate.now())
+                .finishedAt(LocalDate.now().plusMonths(1))
                 .member(member)
                 .build();
 
@@ -216,8 +216,8 @@ class PlanCommandServiceTest {
                 .motivation("목표")
                 .icon("아이콘")
                 .planStatus(PlanStatus.PAUSED)
-                .startedAt(LocalDateTime.now())
-                .finishedAt(LocalDateTime.now().plusMonths(1))
+                .startedAt(LocalDate.now())
+                .finishedAt(LocalDate.now().plusMonths(1))
                 .member(member)
                 .build();
 
@@ -256,8 +256,8 @@ class PlanCommandServiceTest {
                 .motivation("목표")
                 .icon("아이콘")
                 .planStatus(PlanStatus.DELETED)
-                .startedAt(LocalDateTime.now())
-                .finishedAt(LocalDateTime.now().plusMonths(1))
+                .startedAt(LocalDate.now())
+                .finishedAt(LocalDate.now().plusMonths(1))
                 .member(member)
                 .build();
 

--- a/src/test/java/com/planit/planit/plan/service/PlanCommandServiceTest.java
+++ b/src/test/java/com/planit/planit/plan/service/PlanCommandServiceTest.java
@@ -268,7 +268,7 @@ class PlanCommandServiceTest {
         // then
         assertNotNull(result);
         assertThat(result.getTitle()).isEqualTo("제목");
-        assertThat(result.getPlanStatus()).isEqualTo(PlanStatus.ARCHIVED);
+        assertThat(result.getPlanStatus()).isEqualTo(PlanStatus.PAUSED);
     }
 
     @Test

--- a/src/test/java/com/planit/planit/plan/service/PlanCommandServiceTest.java
+++ b/src/test/java/com/planit/planit/plan/service/PlanCommandServiceTest.java
@@ -91,7 +91,7 @@ class PlanCommandServiceTest {
         when(planRepository.save(any(Plan.class))).thenReturn(plan);
 
         // when
-        PlanResponseDTO.PlanMetaDTO result = planCommandService.createPlan(planDTO);
+        PlanResponseDTO.PlanMetaDTO result = planCommandService.createPlan(1L, planDTO);
 
         // then
         assertNotNull(result);
@@ -132,7 +132,7 @@ class PlanCommandServiceTest {
         when(planRepository.save(any(Plan.class))).thenReturn(plan);
 
         // when
-        PlanResponseDTO.PlanMetaDTO result = planCommandService.updatePlan(1L, planDTO);
+        PlanResponseDTO.PlanMetaDTO result = planCommandService.updatePlan(1L, 1L, planDTO);
 
         // then
         assertNotNull(result);
@@ -158,7 +158,7 @@ class PlanCommandServiceTest {
         when(planRepository.findById(1L)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(PlanHandler.class, () -> planCommandService.updatePlan(1L, planDTO));
+        assertThrows(PlanHandler.class, () -> planCommandService.updatePlan(1L, 1L, planDTO));
     }
 
 
@@ -184,7 +184,7 @@ class PlanCommandServiceTest {
         when(planRepository.findById(1L)).thenReturn(Optional.of(plan));
 
         // when
-        PlanResponseDTO.PlanMetaDTO result = planCommandService.completePlan(1L);
+        PlanResponseDTO.PlanMetaDTO result = planCommandService.completePlan(1L, 1L);
 
         // then
         assertNotNull(result);
@@ -199,7 +199,7 @@ class PlanCommandServiceTest {
         when(planRepository.findById(1L)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(PlanHandler.class, () -> planCommandService.completePlan(1L));
+        assertThrows(PlanHandler.class, () -> planCommandService.completePlan(1L, 1L));
     }
 
 
@@ -224,7 +224,7 @@ class PlanCommandServiceTest {
         when(planRepository.findById(1L)).thenReturn(Optional.of(plan));
 
         // when
-        PlanResponseDTO.PlanMetaDTO result = planCommandService.pausePlan(1L);
+        PlanResponseDTO.PlanMetaDTO result = planCommandService.pausePlan(1L, 1L);
 
         // then
         assertNotNull(result);
@@ -239,7 +239,7 @@ class PlanCommandServiceTest {
         when(planRepository.findById(1L)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(PlanHandler.class, () -> planCommandService.pausePlan(1L));
+        assertThrows(PlanHandler.class, () -> planCommandService.pausePlan(1L, 1L));
     }
 
 
@@ -264,7 +264,7 @@ class PlanCommandServiceTest {
         when(planRepository.findById(1L)).thenReturn(Optional.of(plan));
 
         // when
-        PlanResponseDTO.PlanMetaDTO result = planCommandService.deletePlan(1L);
+        PlanResponseDTO.PlanMetaDTO result = planCommandService.deletePlan(1L, 1L);
 
         // then
         assertNotNull(result);
@@ -279,6 +279,6 @@ class PlanCommandServiceTest {
         when(planRepository.findById(1L)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(PlanHandler.class, () -> planCommandService.deletePlan(1L));
+        assertThrows(PlanHandler.class, () -> planCommandService.deletePlan(1L, 1L));
     }
 }

--- a/src/test/java/com/planit/planit/plan/service/PlanQueryServiceTest.java
+++ b/src/test/java/com/planit/planit/plan/service/PlanQueryServiceTest.java
@@ -85,6 +85,7 @@ class PlanQueryServiceTest {
 
     private void initPlan() {
         planInProgress1 = Plan.builder()
+                .id(1L)
                 .title("1")
                 .motivation("다짐문장")
                 .icon("아이콘")
@@ -93,6 +94,7 @@ class PlanQueryServiceTest {
                 .member(member1)
                 .build();
         planInProgress2 = Plan.builder()
+                .id(2L)
                 .title("2")
                 .motivation("다짐문장")
                 .icon("아이콘")
@@ -101,6 +103,7 @@ class PlanQueryServiceTest {
                 .member(member1)
                 .build();
         pausedPlan1 = Plan.builder()
+                .id(3L)
                 .title("3")
                 .motivation("다짐문장")
                 .icon("아이콘")
@@ -109,6 +112,7 @@ class PlanQueryServiceTest {
                 .member(member1)
                 .build();
         pausedPlan2 = Plan.builder()
+                .id(4L)
                 .title("4")
                 .motivation("다짐문장")
                 .icon("아이콘")
@@ -117,6 +121,7 @@ class PlanQueryServiceTest {
                 .member(member1)
                 .build();
         archivedPlan1 = Plan.builder()
+                .id(5L)
                 .title("5")
                 .motivation("다짐문장")
                 .icon("아이콘")
@@ -125,6 +130,7 @@ class PlanQueryServiceTest {
                 .member(member1)
                 .build();
         archivedPlan2 = Plan.builder()
+                .id(6L)
                 .title("6")
                 .motivation("다짐문장")
                 .icon("아이콘")
@@ -136,6 +142,7 @@ class PlanQueryServiceTest {
 
     private void initTask() {
         task1 = Task.builder()
+                .id(1L)
                 .title("작업1")
                 .isRoutine(false)
                 .routineDay(RoutineDay.MON)
@@ -144,14 +151,18 @@ class PlanQueryServiceTest {
                 .plan(planInProgress1)
                 .build();
         task2 = Task.builder()
+                .id(2L)
                 .title("작업2")
                 .isRoutine(false)
                 .routineDay(RoutineDay.MON)
                 .taskType(TaskType.SLOW)
                 .member(member1)
-                .plan(planInProgress2)
+                .plan(planInProgress1)
                 .build();
         task2.completeTask();
+
+        planInProgress1.addTask(task1);
+        planInProgress1.addTask(task2);
     }
 
 

--- a/src/test/java/com/planit/planit/plan/service/PlanQueryServiceTest.java
+++ b/src/test/java/com/planit/planit/plan/service/PlanQueryServiceTest.java
@@ -9,6 +9,7 @@ import com.planit.planit.plan.repository.PlanRepository;
 import com.planit.planit.task.Task;
 import com.planit.planit.task.TaskRepository;
 import com.planit.planit.task.enums.RoutineDay;
+import com.planit.planit.task.enums.TaskType;
 import com.planit.planit.web.dto.plan.PlanResponseDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -88,7 +89,7 @@ class PlanQueryServiceTest {
                 .motivation("다짐문장")
                 .icon("아이콘")
                 .planStatus(PlanStatus.IN_PROGRESS)
-                .finishedAt(LocalDateTime.now())
+                .finishedAt(LocalDate.now())
                 .member(member1)
                 .build();
         planInProgress2 = Plan.builder()
@@ -96,7 +97,7 @@ class PlanQueryServiceTest {
                 .motivation("다짐문장")
                 .icon("아이콘")
                 .planStatus(PlanStatus.IN_PROGRESS)
-                .finishedAt(LocalDateTime.now().plusDays(1))
+                .finishedAt(LocalDate.now().plusDays(1))
                 .member(member1)
                 .build();
         pausedPlan1 = Plan.builder()
@@ -104,7 +105,7 @@ class PlanQueryServiceTest {
                 .motivation("다짐문장")
                 .icon("아이콘")
                 .planStatus(PlanStatus.PAUSED)
-                .finishedAt(LocalDateTime.now())
+                .finishedAt(LocalDate.now())
                 .member(member1)
                 .build();
         pausedPlan2 = Plan.builder()
@@ -112,7 +113,7 @@ class PlanQueryServiceTest {
                 .motivation("다짐문장")
                 .icon("아이콘")
                 .planStatus(PlanStatus.PAUSED)
-                .finishedAt(LocalDateTime.now().plusDays(1))
+                .finishedAt(LocalDate.now().plusDays(1))
                 .member(member1)
                 .build();
         archivedPlan1 = Plan.builder()
@@ -120,7 +121,7 @@ class PlanQueryServiceTest {
                 .motivation("다짐문장")
                 .icon("아이콘")
                 .planStatus(PlanStatus.ARCHIVED)
-                .finishedAt(LocalDateTime.now())
+                .finishedAt(LocalDate.now())
                 .member(member1)
                 .build();
         archivedPlan2 = Plan.builder()
@@ -128,7 +129,7 @@ class PlanQueryServiceTest {
                 .motivation("다짐문장")
                 .icon("아이콘")
                 .planStatus(PlanStatus.ARCHIVED)
-                .finishedAt(LocalDateTime.now().minusDays(1))
+                .finishedAt(LocalDate.now().minusDays(1))
                 .member(member1)
                 .build();
     }
@@ -138,8 +139,7 @@ class PlanQueryServiceTest {
                 .title("작업1")
                 .isRoutine(false)
                 .routineDay(RoutineDay.MON)
-                .taskForWellBeing("컨디션 좋을 때")
-                .taskForDistress("컨디션 나쁠 때")
+                .taskType(TaskType.PASSIONATE)
                 .member(member1)
                 .plan(planInProgress1)
                 .build();
@@ -147,14 +147,37 @@ class PlanQueryServiceTest {
                 .title("작업2")
                 .isRoutine(false)
                 .routineDay(RoutineDay.MON)
-                .taskForWellBeing("컨디션 좋을 때")
-                .taskForDistress("컨디션 나쁠 때")
+                .taskType(TaskType.SLOW)
                 .member(member1)
                 .plan(planInProgress2)
                 .build();
         task2.completeTask();
     }
 
+
+/*------------------------------ 오늘의 플랜 목록 조회 ------------------------------*/
+
+    @Test
+    @DisplayName("오늘의 플랜 목록 조회 (성공)")
+    public void getTodayPlanListTest_Success() {
+
+        // given
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member1));
+        when(planRepository.findAllByMemberIdAndPlanStatus(1L, PlanStatus.IN_PROGRESS))
+                .thenReturn(List.of(planInProgress1, planInProgress2));
+
+        // when
+        PlanResponseDTO.TodayPlanListDTO result = planQueryService.getTodayPlans(1L);
+
+        // then
+        assertNotNull(result);
+        assertThat(result.getTodayDate()).isEqualTo(LocalDate.now());
+        assertThat(result.getPlans().size()).isEqualTo(2);
+        assertThat(result.getPlans().get(0).getTitle()).isEqualTo("1");
+        assertThat(result.getPlans().get(0).getDDay()).isEqualTo("D-Day");
+        assertThat(result.getPlans().get(1).getTitle()).isEqualTo("2");
+        assertThat(result.getPlans().get(1).getDDay()).isEqualTo("D-1");
+    }
 
 /*------------------------------ 플랜 단건 조회 ------------------------------*/
 
@@ -167,7 +190,7 @@ class PlanQueryServiceTest {
         when(planRepository.findById(1L)).thenReturn(Optional.of(planInProgress1));
 
         // when
-        PlanResponseDTO.PlanContentDTO result = planQueryService.getPlan(1L);
+        PlanResponseDTO.PlanContentDTO result = planQueryService.getPlan(1L, 1L);
 
         // then
         assertNotNull(result);
@@ -188,7 +211,7 @@ class PlanQueryServiceTest {
                 .thenReturn(List.of(task1, task2));
 
         // when & then
-        assertThrows(PlanHandler.class, () -> planQueryService.getPlan(1L));
+        assertThrows(PlanHandler.class, () -> planQueryService.getPlan(1L, 1L));
     }
 
     @Test
@@ -208,7 +231,7 @@ class PlanQueryServiceTest {
         when(planRepository.findById(1L)).thenReturn(Optional.of(planInProgress1));
 
         // when & then
-        assertThrows(PlanHandler.class, () -> planQueryService.getPlan(1L));
+        assertThrows(PlanHandler.class, () -> planQueryService.getPlan(1L, 1L));
     }
 
 
@@ -224,7 +247,7 @@ class PlanQueryServiceTest {
                 .thenReturn(List.of(planInProgress1, planInProgress2));
 
         // when
-        PlanResponseDTO.PlanListDTO result = planQueryService.getPlansByPlanStatus(PlanStatus.IN_PROGRESS);
+        PlanResponseDTO.PlanListDTO result = planQueryService.getPlansByPlanStatus(1L, PlanStatus.IN_PROGRESS);
 
         // then
         assertNotNull(result);
@@ -245,7 +268,7 @@ class PlanQueryServiceTest {
                 .thenReturn(List.of(pausedPlan1, pausedPlan2));
 
         // when
-        PlanResponseDTO.PlanListDTO result = planQueryService.getPlansByPlanStatus(PlanStatus.PAUSED);
+        PlanResponseDTO.PlanListDTO result = planQueryService.getPlansByPlanStatus(1L, PlanStatus.PAUSED);
 
         // then
         assertNotNull(result);
@@ -266,7 +289,7 @@ class PlanQueryServiceTest {
                 .thenReturn(List.of(archivedPlan1, archivedPlan2));
 
         // when
-        PlanResponseDTO.PlanListDTO result = planQueryService.getPlansByPlanStatus(PlanStatus.ARCHIVED);
+        PlanResponseDTO.PlanListDTO result = planQueryService.getPlansByPlanStatus(1L, PlanStatus.ARCHIVED);
 
         // then
         assertNotNull(result);


### PR DESCRIPTION
## 연관된 이슈

> 이슈 번호를 작성해주세요

- #43 

<br>

## 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- 플랜과 관련된 API를 구현하였습니다.
- UI 업데이트에 따라 도메인이 일부 수정된 부분이 있습니다.
  - 회원의 마지막 출석일, 현재 연속일, 연속일 최고기록, 완벽 연속일을 별도의 필드로 관리합니다.
  - 플랜의 startedAt과 finishedAt이 LocalDateTime에서 LocalDate로 변경되었습니다.
  - 작업에서 taskForWellBeing, taskForDistress 필드가 삭제되고 taskType(ALL, SLOW, PASSIONATE)이 추가되었습니다.

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 확인해주셔서 감사합니다 😁
