### PR TITLE
[PL-115] Test: "MemberRepository 테스트 코드 작성"

### DIFF
--- a/src/test/java/com/planit/planit/member/MemberRepositoryTest.java
+++ b/src/test/java/com/planit/planit/member/MemberRepositoryTest.java
@@ -1,0 +1,122 @@
+package com.planit.planit.member;
+
+import com.planit.planit.member.enums.Role;
+import com.planit.planit.member.enums.SignType;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest // JPA 관련 컴포넌트만 로드하여 테스트
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY) // 내장 DB 사용 (테스트용)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @Order(1)
+    @DisplayName("새로운 멤버 저장 가능(성공)")
+    @Transactional
+    public void testSaveMember(){
+        //given
+        Member newMember = Member.builder()
+                .email("test@example.com")
+                .password("password")
+                .signType(SignType.GOOGLE)
+                .guiltyFreeMode(false)
+                .memberName("테스터")
+                .role(Role.USER)
+                .build();
+
+        //when
+        Member savedMember = memberRepository.save(newMember);
+
+        //then
+        assertThat(savedMember).isNotNull();
+        assertThat(savedMember.getId()).isNotNull();
+        assertThat(savedMember.getEmail()).isEqualTo("test@example.com");
+        assertThat(savedMember.getMemberName()).isEqualTo("테스터");
+        assertThat(savedMember.getRole()).isEqualTo(Role.USER);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("이메일로 멤버를 조회할 수 있다")
+    @Transactional
+    void testFindByEmail_ExistingMember() {
+        // Given
+        Member existingMember = Member.builder()
+                .email("existing@example.com")
+                .password("password")
+                .signType(SignType.GOOGLE)
+                .guiltyFreeMode(false)
+                .memberName("기존회원")
+                .role(Role.USER)
+                .build();
+        memberRepository.save(existingMember);
+
+        // When
+        Optional<Member> foundMember = memberRepository.findByEmail("existing@example.com");
+
+        // Then
+        assertThat(foundMember).isPresent();
+        assertThat(foundMember.get().getEmail()).isEqualTo("existing@example.com");
+        assertThat(foundMember.get().getMemberName()).isEqualTo("기존회원");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일로 조회 시 비어있는 Optional을 반환한다")
+    @Order(3)
+    @Transactional
+    void testFindByEmail_NonExistingMember() {
+        // Given
+
+        // When
+        Optional<Member> foundMember = memberRepository.findByEmail("nonexistent@example.com");
+
+        // Then
+        assertThat(foundMember).isEmpty();
+    }
+
+    @Test
+    @DisplayName("중복된 이메일로 저장 시 예외가 발생한다")
+    @Order(4)
+    @Transactional
+    void testSaveDuplicateEmailThrowsException() {
+        // Given
+        Member member1 = Member.builder()
+                .email("duplicate@example.com")
+                .password("password")
+                .signType(SignType.KAKAO)
+                .guiltyFreeMode(false)
+                .memberName("중복1")
+                .role(Role.USER)
+                .build();
+        memberRepository.save(member1);
+
+        Member member2 = Member.builder()
+                .email("duplicate@example.com") // 중복 이메일
+                .password("pad456")
+                .signType(SignType.KAKAO)
+                .guiltyFreeMode(false)
+                .memberName("중복2")
+                .role(Role.USER)
+                .build();
+
+        // When & Then
+        // 중복 이메일 저장은 DataIntegrityViolationException을 발생시켜야 함
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            memberRepository.saveAndFlush(member2); //saveFlush로 바로 에러 발생시킬 수 있게 함. 서비스에서는 MemberHandler로 오류 반환
+        });
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

> 이슈 번호를 작성해주세요

- #59 

<br>

## 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- MemberRepository 테스트 코드 작성하였습니다. 

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 원래 RegisterDTO 쪽 만드려고 했는데, 피그마를 보니까 일반 로그인이 없는 것 같기도 하고, memberName을 언제 등록하는 건지 몰라서 DTO 설정이 좀 애매해졌습니다. 그래서 일단 효림님께서 답해주시기 전까지는 DTO 쪽은 빼놓고 구현하고자 합니다. 
```
- TDD가 처음이라 
        // When & Then
        // 중복 이메일 저장은 DataIntegrityViolationException을 발생시켜야 함
        assertThrows(DataIntegrityViolationException.class, () -> {
            memberRepository.saveAndFlush(member2); //saveFlush로 바로 에러 발생시킬 수 있게 함. 서비스에서는 MemberHandler로 오류 반환
        });
    }
}
```
이쪽에서 오류 반환하는게 이렇게 하는 게 맞는지 모르겟네요. 찾아보니까 저장소 레벨이기 떄문에 이렇게 던지고, 서비스나 컨트롤러 계층에서는 MemberHandler로 하던대로 던지면 된다고 하는데, 혹시 이게 틀린 거면 말씀해주시면 감사하겠습니다.
