### PR TITLE
[PL-116] Test: "MemberServiceImpl 테스트 코드 작성 및 createToken 함수 세분화

### DIFF
--- a/src/main/java/com/planit/planit/config/jwt/JwtProvider.java
+++ b/src/main/java/com/planit/planit/config/jwt/JwtProvider.java
@@ -28,12 +28,20 @@ public class JwtProvider {
         this.audiences = jwtProperties.getAudiences();
     }
 
-    public String createToken(Long id, String email, String name, String role) {
+    public String createAccessToken(Long id, String email, String name, String role) {
+        return createToken(id, email, name, role, expirationMs);
+    }
+
+    public String createRefreshToken(Long id, String email, String name, String role) {
+        return createToken(id, email, name, role, refreshTokenExpirationMs);
+    }
+
+    private String createToken(Long id, String email, String name, String role, long expirationMs) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + expirationMs);
 
         return Jwts.builder()
-                .setSubject(String.valueOf(id)) // sub: id
+                .setSubject(String.valueOf(id))
                 .claim("email", email)
                 .claim("memberName", name)
                 .claim("role", role)

--- a/src/main/java/com/planit/planit/member/service/MemberService.java
+++ b/src/main/java/com/planit/planit/member/service/MemberService.java
@@ -1,0 +1,11 @@
+package com.planit.planit.member.service;
+
+import com.planit.planit.member.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface MemberService {
+
+
+}

--- a/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
@@ -1,0 +1,17 @@
+package com.planit.planit.member.service;
+
+
+import com.planit.planit.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+
+
+}

--- a/src/test/java/com/planit/planit/auth/FakeOAuth2User.java
+++ b/src/test/java/com/planit/planit/auth/FakeOAuth2User.java
@@ -1,0 +1,31 @@
+package com.planit.planit.auth;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class FakeOAuth2User implements OAuth2User {
+    private final Map<String, Object> attributes;
+
+    public FakeOAuth2User(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.getOrDefault("name", "unknown");
+    }
+}

--- a/src/test/java/com/planit/planit/jwt/JwtProviderTest.java
+++ b/src/test/java/com/planit/planit/jwt/JwtProviderTest.java
@@ -20,6 +20,7 @@ class JwtProviderTest {
         long expiration = 3600000; // 1시간
         jwtProperties.setSecret(secretKey);
         jwtProperties.setExpirationMs(expiration);
+        jwtProperties.setRefreshTokenExpirationMs(expiration);
         jwtProvider = new JwtProvider(jwtProperties);
     }
 
@@ -34,7 +35,7 @@ class JwtProviderTest {
         String role = "USER";
 
         // when
-        String token = jwtProvider.createToken(userId, email, memberName, role);
+        String token = jwtProvider.createAccessToken(userId, email, memberName, role);
 
         // then
         assertThat(jwtProvider.validateToken(token)).isTrue();
@@ -51,10 +52,32 @@ class JwtProviderTest {
         jwtProperties.setExpirationMs(1);
         jwtProperties.setSecret("\"short-key-which-is-long-enough-for-test-purpose\"");
         JwtProvider shortLivedProvider = new JwtProvider(jwtProperties);
-        String token = shortLivedProvider.createToken(1L, "a@a.com", "Test", "USER");
+        String token = shortLivedProvider.createAccessToken(1L, "a@a.com", "Test", "USER");
 
         Thread.sleep(10); // 토큰 만료 기다림
 
         assertThat(shortLivedProvider.validateToken(token)).isFalse();
     }
+
+    @Test
+    @Order(3)
+    @DisplayName("RefreshToken 생성 및 파싱 (성공)")
+    void 리프레시_토큰_생성_및_파싱_테스트() {
+        // given
+        Long userId = 84L;
+        String email = "refresh@example.com";
+        String memberName = "리프레시";
+        String role = "USER";
+
+        // when
+        String refreshToken = jwtProvider.createRefreshToken(userId, email, memberName, role);
+
+        // then
+        assertThat(jwtProvider.validateToken(refreshToken)).isTrue();
+        assertThat(jwtProvider.getId(refreshToken)).isEqualTo(userId);
+        assertThat(jwtProvider.getEmail(refreshToken)).isEqualTo(email);
+        assertThat(jwtProvider.getMemberName(refreshToken)).isEqualTo(memberName);
+        assertThat(jwtProvider.getRole(refreshToken)).isEqualTo(role);
+    }
+
 }

--- a/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
@@ -1,0 +1,99 @@
+package com.planit.planit.member.service;
+
+import com.planit.planit.auth.FakeOAuth2User;
+import com.planit.planit.config.jwt.JwtProvider;
+import com.planit.planit.member.Member;
+import com.planit.planit.member.MemberRepository;
+import com.planit.planit.member.enums.Role;
+import com.planit.planit.member.enums.SignType;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Transactional
+class MemberServiceImplTest {
+
+    @InjectMocks
+    private MemberServiceImpl memberServiceImpl;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Test
+    @Order(1)
+    @Transactional
+    @DisplayName("신규 회원이면 회원가입 처리되고 isNewMember=false 를 반환한다 (실패)")
+    void register_isNewMember_false_return() {
+        // given
+        Map<String, Object> attributes = Map.of(
+                "email", "newbie@gmail.com",
+                "name", "뉴비",
+                "picture", "https://image.url"
+        );
+
+        OAuth2User oAuth2User = new FakeOAuth2User(attributes);
+
+        given(memberRepository.findByEmail("newbie@gmail.com"))
+                .willReturn(Optional.empty());
+
+        given(memberRepository.save(any()))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        given(jwtProvider.createAccessToken(any(), any(), any(), any()))
+                .willReturn("access-token");
+
+        given(jwtProvider.createRefreshToken(any(), any(), any(), any()))
+                .willReturn("refresh-token");
+
+         //when
+         OAuthLoginResponse response = memberServiceImpl.oauthRegister(oAuth2User, SignType.GOOGLE);
+
+         //then
+         assertThat(response.isNewMember()).isFalse();
+         assertThat(response.getEmail()).isEqualTo("newbie@gmail.com");
+         assertThat(response.getAccessToken()).isEqualTo("access-token");
+        assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
+    }
+
+    @Test
+    @Order(2)
+    @Transactional
+    @DisplayName("기존 회원이면 isNewMember가 true로 반환된다 (실패)")
+    void if_existingMember_isNewMember_true() {
+        // given
+        OAuth2User user = new FakeOAuth2User(Map.of(
+                "email", "existing@planit.com",
+                "name", "플래닛유저"
+        ));
+        Member existingMember = Member.builder()
+                .email("existing@planit.com")
+                .memberName("플래닛유저")
+                .role(Role.USER)
+                .build();
+        given(memberRepository.findByEmail("existing@planit.com")).willReturn(Optional.of(existingMember));
+        given(jwtProvider.createAccessToken(any(), any(), any(), any())).willReturn("access-token");
+        given(jwtProvider.createRefreshToken(any(), any(), any(), any())).willReturn("refresh-token");
+
+        // when
+        OAuthLoginResponse response = memberServiceImpl.oauthRegister(user, SignType.GOOGLE);
+
+        // then
+        assertThat(response.isNewMember()).isTrue(); // 기존 회원이므로 true
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

> 이슈 번호를 작성해주세요

- #61 

<br>

## 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- memberServiceImpl 테스트 코드 작성하였습니다. Oauth2User를 Mock해야 하는데, provider가 세개라서 일일히 Mock하기는 너무 귀찮아, FakeOauth2User로 추상화해서 작업했습니다.

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

-  현재 닉네임을 어느 부분에서 등록하는지 모르겠어서 밑에 있는 OauthLoginResponse 그쪽은 DTO를 안만들어놨습니다. (만약 Oauth정보로만 회원가입을 진행하는지 유무에 따라, LoginResponse랑 RegisterResponse랑 합칠지 달라져서) 그래서 실패하는 상태입니다. 확정되면 그부분만 수정 하도록 하겠습니다.  
