### PR TITLE
[PL-123] Feat: MemberService 기능 구현

### DIFF
--- a/src/main/java/com/planit/planit/common/api/member/status/MemberErrorStatus.java
+++ b/src/main/java/com/planit/planit/common/api/member/status/MemberErrorStatus.java
@@ -4,7 +4,8 @@ import com.planit.planit.common.api.general.status.ErrorResponse;
 import org.springframework.http.HttpStatus;
 
 public enum MemberErrorStatus implements ErrorResponse {
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "회원을 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "회원을 찾을 수 없습니다."),
+    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER4002", "이미 가입된 회원입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/planit/planit/config/SecurityConfig.java
+++ b/src/main/java/com/planit/planit/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.planit.planit.config;
 
 
 import com.planit.planit.config.jwt.JwtAuthenticationFilter;
+import com.planit.planit.config.oauth.CustomOAuth2User;
+import com.planit.planit.config.oauth.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter  jwtAuthenticationFilter;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -24,6 +27,11 @@ public class SecurityConfig {
                 authorizeRequests.anyRequest().permitAll() )
                 .cors(cors -> cors.disable()) //TODO: 배포 시 CORS 설정
                 .csrf(csrf -> csrf.disable())
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)
+                        )
+                )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/planit/planit/config/jwt/JwtProvider.java
+++ b/src/main/java/com/planit/planit/config/jwt/JwtProvider.java
@@ -1,4 +1,5 @@
 package com.planit.planit.config.jwt;
+import com.planit.planit.member.enums.Role;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,15 +29,15 @@ public class JwtProvider {
         this.audiences = jwtProperties.getAudiences();
     }
 
-    public String createAccessToken(Long id, String email, String name, String role) {
+    public String createAccessToken(Long id, String email, String name, Role role) {
         return createToken(id, email, name, role, expirationMs);
     }
 
-    public String createRefreshToken(Long id, String email, String name, String role) {
+    public String createRefreshToken(Long id, String email, String name, Role role) {
         return createToken(id, email, name, role, refreshTokenExpirationMs);
     }
 
-    private String createToken(Long id, String email, String name, String role, long expirationMs) {
+    private String createToken(Long id, String email, String name, Role role, long expirationMs) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + expirationMs);
 

--- a/src/main/java/com/planit/planit/config/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/planit/planit/config/oauth/CustomOAuth2User.java
@@ -1,0 +1,34 @@
+package com.planit.planit.config.oauth;
+
+import com.planit.planit.member.enums.SignType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+    private final OAuth2User delegate;
+    @Getter
+    private final SignType signType;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return delegate.getAttributes();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return delegate.getAuthorities();
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+}

--- a/src/main/java/com/planit/planit/config/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/planit/planit/config/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,28 @@
+package com.planit.planit.config.oauth;
+
+import com.planit.planit.member.enums.SignType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        // registrationId: "google", "kakao" 등
+        String registrationId = userRequest.getClientRegistration().getRegistrationId().toUpperCase();
+        SignType signType = SignType.valueOf(registrationId);
+
+        return new CustomOAuth2User(oAuth2User, signType);
+    }
+}

--- a/src/main/java/com/planit/planit/member/association/TermRepository.java
+++ b/src/main/java/com/planit/planit/member/association/TermRepository.java
@@ -1,0 +1,9 @@
+package com.planit.planit.member.association;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TermRepository extends JpaRepository<Term, Long> {
+
+}

--- a/src/main/java/com/planit/planit/member/service/MemberService.java
+++ b/src/main/java/com/planit/planit/member/service/MemberService.java
@@ -1,11 +1,21 @@
 package com.planit.planit.member.service;
 
+import com.planit.planit.config.oauth.CustomOAuth2User;
 import com.planit.planit.member.MemberRepository;
+import com.planit.planit.member.enums.SignType;
+import com.planit.planit.web.dto.auth.login.converter.OAuthLoginDTO;
+import com.planit.planit.web.dto.member.term.TermAgreementDTO;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface MemberService {
 
+    //로그인인지 회원가입인지 감지
+    OAuthLoginDTO.Response checkOAuthMember(CustomOAuth2User oAuth2User);
 
+    OAuthLoginDTO.Response checkOAuthMember(OAuth2User oAuth2User, SignType signType);
+
+    OAuthLoginDTO.Response registerOAuthMember(CustomOAuth2User oAuth2User, TermAgreementDTO.Request request);
 }

--- a/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
@@ -1,10 +1,24 @@
 package com.planit.planit.member.service;
 
 
+import com.planit.planit.common.api.member.MemberHandler;
+import com.planit.planit.common.api.member.status.MemberErrorStatus;
+import com.planit.planit.config.jwt.JwtProvider;
+import com.planit.planit.config.oauth.CustomOAuth2User;
+import com.planit.planit.member.Member;
 import com.planit.planit.member.MemberRepository;
+import com.planit.planit.member.association.Term;
+import com.planit.planit.member.association.TermRepository;
+import com.planit.planit.member.enums.Role;
+import com.planit.planit.member.enums.SignType;
+import com.planit.planit.web.dto.auth.login.converter.OAuthLoginDTO;
+import com.planit.planit.web.dto.member.term.TermAgreementDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -12,6 +26,98 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
+    private final TermRepository termRepository;
+    private final JwtProvider jwtProvider;
+
+    //로그인인지 회원가입인지 감지
+    @Override
+    public OAuthLoginDTO.Response checkOAuthMember(CustomOAuth2User oAuth2User) {
+        String email = (String) oAuth2User.getAttributes().get("email");
+        String name = (String) oAuth2User.getAttributes().get("name");
+
+        Optional<Member> optionalMember = memberRepository.findByEmail(email);
+
+        if (optionalMember.isPresent()) {
+            Member member = optionalMember.get();
+
+            String accessToken = jwtProvider.createAccessToken(
+                    member.getId(), member.getEmail(), member.getMemberName(), member.getRole()
+            );
+
+            String refreshToken = jwtProvider.createRefreshToken(
+                    member.getId(), member.getEmail(), member.getMemberName(), member.getRole()
+            );
+
+            return OAuthLoginDTO.Response.builder()
+                    .email(member.getEmail())
+                    .name(member.getMemberName())
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .isNewMember(false)
+                    .build();
+        }
+
+        // 신규 회원 → 약관 동의 필요
+        return OAuthLoginDTO.Response.builder()
+                .email(email)
+                .name(name)
+                .accessToken(null)
+                .refreshToken(null)
+                .isNewMember(true)
+                .build();
+    }
+
+    @Override
+    public OAuthLoginDTO.Response checkOAuthMember(OAuth2User oAuth2User, SignType signType) {
+        return null;
+    }
+
+    @Override
+    public OAuthLoginDTO.Response registerOAuthMember(CustomOAuth2User oAuth2User, TermAgreementDTO.Request request) {
+        String email = (String) oAuth2User.getAttributes().get("email");
+        String name = (String) oAuth2User.getAttributes().get("name");
+        SignType signType = oAuth2User.getSignType();
+
+
+        //혹시 오류 생길까봐 넣긴 했는데, 중복 확인이라 고민입니다
+        if (memberRepository.findByEmail(email).isPresent()) {
+            throw new MemberHandler(MemberErrorStatus.MEMBER_ALREADY_EXISTS);
+        }
+
+        Member member = Member.builder()
+                .email(email)
+                .memberName(name)
+                .signType(SignType.GOOGLE)  // 또는 매개변수로 받아도 됨
+                .guiltyFreeMode(false)
+                .role(Role.USER)
+                .build();
+        memberRepository.save(member);
+
+        Term term = Term.builder()
+                .member(member)
+                .termOfUse(request.getTermOfUse())
+                .termOfPrivacy(request.getTermOfPrivacy())
+                .build();
+        termRepository.save(term);
+
+        String accessToken = jwtProvider.createAccessToken(
+                member.getId(), member.getEmail(), member.getMemberName(), member.getRole()
+        );
+
+        String refreshToken = jwtProvider.createRefreshToken(
+                member.getId(), member.getEmail(), member.getMemberName(), member.getRole()
+        );
+
+        return OAuthLoginDTO.Response.builder()
+                .email(member.getEmail())
+                .name(member.getMemberName())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .isNewMember(true)
+                .build();
+    }
+
+
 
 
 }

--- a/src/main/java/com/planit/planit/web/dto/member/term/TermAgreementDTO.java
+++ b/src/main/java/com/planit/planit/web/dto/member/term/TermAgreementDTO.java
@@ -1,0 +1,24 @@
+package com.planit.planit.web.dto.member.term;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class TermAgreementDTO {
+
+    @Getter
+    @Builder
+    public static class Request {
+        private LocalDateTime termOfUse;
+        private LocalDateTime termOfPrivacy;
+    }
+
+    @Getter
+    @Builder
+    public static class Response {
+        private String email;
+        private LocalDateTime termOfUse;
+        private LocalDateTime termOfPrivacy;
+    }
+}

--- a/src/test/java/com/planit/planit/auth/FakeCustomOAuth2User.java
+++ b/src/test/java/com/planit/planit/auth/FakeCustomOAuth2User.java
@@ -1,0 +1,13 @@
+package com.planit.planit.auth;
+
+import com.planit.planit.config.oauth.CustomOAuth2User;
+import com.planit.planit.member.enums.SignType;
+
+import java.util.Map;
+
+public class FakeCustomOAuth2User extends CustomOAuth2User {
+
+    public FakeCustomOAuth2User(Map<String, Object> attributes, SignType signType) {
+        super(new FakeOAuth2User(attributes), signType);
+    }
+}

--- a/src/test/java/com/planit/planit/auth/FakeOAuth2User.java
+++ b/src/test/java/com/planit/planit/auth/FakeOAuth2User.java
@@ -4,10 +4,10 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 public class FakeOAuth2User implements OAuth2User {
+
     private final Map<String, Object> attributes;
 
     public FakeOAuth2User(Map<String, Object> attributes) {
@@ -21,11 +21,11 @@ public class FakeOAuth2User implements OAuth2User {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of();
+        return null;
     }
 
     @Override
     public String getName() {
-        return (String) attributes.getOrDefault("name", "unknown");
+        return null;
     }
 }

--- a/src/test/java/com/planit/planit/config/oauth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/planit/planit/config/oauth/JwtAuthenticationFilterTest.java
@@ -52,7 +52,7 @@ class JwtAuthenticationFilterTest {
     void 유효한_AccessToken이_있으면_인증_객체가_생성된다() throws ServletException, IOException {
         // given
         Long userId = 1L;
-        String accessToken = jwtProvider.createAccessToken(userId, "user@example.com", "홍길동", "USER");
+        String accessToken = jwtProvider.createAccessToken(userId, "user@example.com", "홍길동", Role.USER);
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Authorization", "Bearer " + accessToken); // ⬅ 수정됨

--- a/src/test/java/com/planit/planit/jwt/JwtProviderTest.java
+++ b/src/test/java/com/planit/planit/jwt/JwtProviderTest.java
@@ -2,9 +2,11 @@ package com.planit.planit.jwt;
 
 import com.planit.planit.config.jwt.JwtProperties;
 import com.planit.planit.config.jwt.JwtProvider;
+import com.planit.planit.member.enums.Role;
 import org.junit.jupiter.api.*;
 
 
+import static com.planit.planit.member.enums.Role.USER;
 import static org.assertj.core.api.Assertions.*;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -32,7 +34,7 @@ class JwtProviderTest {
         Long userId = 42L;
         String email = "user@example.com";
         String memberName = "홍길동";
-        String role = "USER";
+        Role role = USER;
 
         // when
         String token = jwtProvider.createAccessToken(userId, email, memberName, role);
@@ -52,7 +54,7 @@ class JwtProviderTest {
         jwtProperties.setExpirationMs(1);
         jwtProperties.setSecret("\"short-key-which-is-long-enough-for-test-purpose\"");
         JwtProvider shortLivedProvider = new JwtProvider(jwtProperties);
-        String token = shortLivedProvider.createAccessToken(1L, "a@a.com", "Test", "USER");
+        String token = shortLivedProvider.createAccessToken(1L, "a@a.com", "Test", USER);
 
         Thread.sleep(10); // 토큰 만료 기다림
 
@@ -67,7 +69,7 @@ class JwtProviderTest {
         Long userId = 84L;
         String email = "refresh@example.com";
         String memberName = "리프레시";
-        String role = "USER";
+        Role role = USER;
 
         // when
         String refreshToken = jwtProvider.createRefreshToken(userId, email, memberName, role);

--- a/src/test/java/com/planit/planit/member/MemberRepositoryTest.java
+++ b/src/test/java/com/planit/planit/member/MemberRepositoryTest.java
@@ -25,7 +25,7 @@ class MemberRepositoryTest {
 
     @Test
     @Order(1)
-    @DisplayName("새로운 멤버 저장 가능(성공)")
+    @DisplayName("새로운 멤버 저장 가능-성공")
     @Transactional
     public void testSaveMember(){
         //given
@@ -51,7 +51,7 @@ class MemberRepositoryTest {
 
     @Test
     @Order(2)
-    @DisplayName("이메일로 멤버를 조회할 수 있다")
+    @DisplayName("이메일로 멤버를 조회할 수 있다-성공")
     @Transactional
     void testFindByEmail_ExistingMember() {
         // Given
@@ -75,7 +75,7 @@ class MemberRepositoryTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 이메일로 조회 시 비어있는 Optional을 반환한다")
+    @DisplayName("존재하지 않는 이메일로 조회 시 비어있는 Optional을 반환한다-성공")
     @Order(3)
     @Transactional
     void testFindByEmail_NonExistingMember() {
@@ -89,7 +89,7 @@ class MemberRepositoryTest {
     }
 
     @Test
-    @DisplayName("중복된 이메일로 저장 시 예외가 발생한다")
+    @DisplayName("중복된 이메일로 저장 시 예외가 발생한다-성공")
     @Order(4)
     @Transactional
     void testSaveDuplicateEmailThrowsException() {

--- a/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
@@ -40,7 +40,7 @@ class MemberServiceImplTest {
 
     @Test
     @Order(1)
-    @DisplayName("신규 회원이면 회원가입 처리되고 isNewMember = true 를 반환한다")
+    @DisplayName("신규 회원이면 회원가입 처리되고 isNewMember = true 를 반환한다-성공")
     void register_newMember_returnsTrue() {
         // given
         Map<String, Object> attributes = Map.of(
@@ -63,7 +63,7 @@ class MemberServiceImplTest {
 
     @Test
     @Order(2)
-    @DisplayName("기존 회원이면 isNewMember = false 를 반환한다")
+    @DisplayName("기존 회원이면 isNewMember = false 를 반환한다-성공")
     void register_existingMember_returnsFalse() {
         // given
         Map<String, Object> attributes = Map.of(

--- a/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
@@ -1,11 +1,13 @@
 package com.planit.planit.member.service;
 
+import com.planit.planit.auth.FakeCustomOAuth2User;
 import com.planit.planit.auth.FakeOAuth2User;
 import com.planit.planit.config.jwt.JwtProvider;
 import com.planit.planit.member.Member;
 import com.planit.planit.member.MemberRepository;
 import com.planit.planit.member.enums.Role;
 import com.planit.planit.member.enums.SignType;
+import com.planit.planit.web.dto.auth.login.converter.OAuthLoginDTO;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -20,6 +22,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -37,23 +40,48 @@ class MemberServiceImplTest {
 
     @Test
     @Order(1)
-    @Transactional
-    @DisplayName("신규 회원이면 회원가입 처리되고 isNewMember=false 를 반환한다 (실패)")
-    void register_isNewMember_false_return() {
+    @DisplayName("신규 회원이면 회원가입 처리되고 isNewMember = true 를 반환한다")
+    void register_newMember_returnsTrue() {
         // given
         Map<String, Object> attributes = Map.of(
                 "email", "newbie@gmail.com",
-                "name", "뉴비",
-                "picture", "https://image.url"
+                "name", "뉴비"
         );
-
-        OAuth2User oAuth2User = new FakeOAuth2User(attributes);
+        FakeCustomOAuth2User user = new FakeCustomOAuth2User(attributes, SignType.GOOGLE);
 
         given(memberRepository.findByEmail("newbie@gmail.com"))
                 .willReturn(Optional.empty());
 
-        given(memberRepository.save(any()))
-                .willAnswer(invocation -> invocation.getArgument(0));
+        // when
+        var response = memberServiceImpl.checkOAuthMember(user);
+
+        // then
+        assertThat(response.isNewMember()).isTrue();
+        assertThat(response.getEmail()).isEqualTo("newbie@gmail.com");
+
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("기존 회원이면 isNewMember = false 를 반환한다")
+    void register_existingMember_returnsFalse() {
+        // given
+        Map<String, Object> attributes = Map.of(
+                "email", "exist@planit.com",
+                "name", "플래닛"
+        );
+        var user = new FakeCustomOAuth2User(attributes, SignType.GOOGLE);
+
+        var existing = Member.builder()
+                .email("exist@planit.com")
+                .memberName("플래닛")
+                .role(Role.USER)
+                .signType(SignType.GOOGLE)
+                .guiltyFreeMode(false)
+                .build();
+
+        given(memberRepository.findByEmail("exist@planit.com"))
+                .willReturn(Optional.of(existing));
 
         given(jwtProvider.createAccessToken(any(), any(), any(), any()))
                 .willReturn("access-token");
@@ -61,39 +89,13 @@ class MemberServiceImplTest {
         given(jwtProvider.createRefreshToken(any(), any(), any(), any()))
                 .willReturn("refresh-token");
 
-         //when
-         OAuthLoginResponse response = memberServiceImpl.oauthRegister(oAuth2User, SignType.GOOGLE);
-
-         //then
-         assertThat(response.isNewMember()).isFalse();
-         assertThat(response.getEmail()).isEqualTo("newbie@gmail.com");
-         assertThat(response.getAccessToken()).isEqualTo("access-token");
-        assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
-    }
-
-    @Test
-    @Order(2)
-    @Transactional
-    @DisplayName("기존 회원이면 isNewMember가 true로 반환된다 (실패)")
-    void if_existingMember_isNewMember_true() {
-        // given
-        OAuth2User user = new FakeOAuth2User(Map.of(
-                "email", "existing@planit.com",
-                "name", "플래닛유저"
-        ));
-        Member existingMember = Member.builder()
-                .email("existing@planit.com")
-                .memberName("플래닛유저")
-                .role(Role.USER)
-                .build();
-        given(memberRepository.findByEmail("existing@planit.com")).willReturn(Optional.of(existingMember));
-        given(jwtProvider.createAccessToken(any(), any(), any(), any())).willReturn("access-token");
-        given(jwtProvider.createRefreshToken(any(), any(), any(), any())).willReturn("refresh-token");
-
         // when
-        OAuthLoginResponse response = memberServiceImpl.oauthRegister(user, SignType.GOOGLE);
+        var response = memberServiceImpl.checkOAuthMember(user);
 
         // then
-        assertThat(response.isNewMember()).isTrue(); // 기존 회원이므로 true
+        assertThat(response.isNewMember()).isFalse();
+        assertThat(response.getEmail()).isEqualTo("exist@planit.com");
+        verify(jwtProvider).createAccessToken(any(), any(), any(), any());
+        verify(jwtProvider).createRefreshToken(any(), any(), any(), any());
     }
 }


### PR DESCRIPTION
## 연관된 이슈

> 이슈 번호를 작성해주세요

-  #63  

<br>

## 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- CustomOAuth2User 클래스 구현
OAuth2User를 확장해 SignType 정보를 포함하도록 커스텀한 사용자 클래스 작성
기존 OAuth2USer는 SignType을 못받아서, 별도로 RequestMapping으로 SignType을 넣어줘야 했습니다.
그럼 비효율적이라 CustomOAuth2User 클래스를 만들어서, 거기 안에 SignType까지 같이 넣습니다. 

- FakeCustomOAuth2User 테스트 클래스 작성
단위 테스트용으로 CustomOAuth2User를 모킹하는 Fake 클래스 구현

- MemberService의 OAuth 로그인 로직 리팩토링
기존 OAuth2User 대신 CustomOAuth2User를 받아서 signType을 내부에서 처리하도록 변경
로그인/회원가입 여부 판단 메서드(checkOAuthMember) 개선

소셜 로그인 하는 건 똑같고, 회원가입 유무에 따라서 회원가입인지 바로 로그인인지 달라지기 때문에 판단 메서드를 넣었습니다. 


- SecurityConfig에 CustomOAuth2UserService 등록
Spring Security OAuth2 로그인 시 사용자 정보를 커스텀하여 처리하도록 설정 추가

- MemberServiceImpl 단위 테스트 수정
FakeCustomOAuth2User를 사용하도록 테스트 코드 변경 및 불필요한 stub 정리


<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 커밋 순서를 반대로... 해버렸슴다 ㅠㅠ
