### PR TITLE
[PL-151] [task] 작업 루틴 다중 선택 가능하게 수정

### DIFF
--- a/src/main/java/com/planit/planit/task/Task.java
+++ b/src/main/java/com/planit/planit/task/Task.java
@@ -12,7 +12,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -30,9 +29,8 @@ public class Task extends BaseEntity {
     @Column(nullable = false, length = 30)
     private String title;
 
-    @Enumerated(EnumType.STRING)
-    @Column
-    private DayOfWeek routineDay;
+    @Column(nullable = false)
+    private Byte routine;
 
     @Column
     private LocalTime routineTime;
@@ -72,7 +70,7 @@ public class Task extends BaseEntity {
         this.id = id;
         this.title = title;
         this.taskType = TaskType.ALL;
-        this.routineDay = DayOfWeek.MONDAY;
+        this.routine = 0;
         this.member = member;
         this.plan = plan;
         this.completedTasks = new ArrayList<>();
@@ -86,11 +84,11 @@ public class Task extends BaseEntity {
 
     public void setRoutine(
             TaskType taskType,
-            DayOfWeek routineDay,
+            Byte routine,
             @Nullable LocalTime routineTime
     ) {
         this.taskType = taskType;
-        this.routineDay = routineDay;
+        this.routine = routine;
         this.routineTime = routineTime;
     }
 

--- a/src/main/java/com/planit/planit/task/converter/RoutineConverter.java
+++ b/src/main/java/com/planit/planit/task/converter/RoutineConverter.java
@@ -1,0 +1,54 @@
+package com.planit.planit.task.converter;
+
+import java.time.DayOfWeek;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RoutineConverter {
+
+    /**
+     * Byte로 저장된 루틴을 List<DayOfWeek>로 변환
+     * @param routineByte : Byte 루틴
+     * @return DayOfWeek 리스트
+     * MON(1) : 0000 0001
+     * TUE(2) : 0000 0010
+     * ...
+     * SUN(7) : 0100 0000
+     */
+    public static List<DayOfWeek> byteToRoutineDays(Byte routineByte)  {
+        List<DayOfWeek> routineDays = new ArrayList<>();
+
+        for (int i=0; i<7; i++) {
+            // routineDay를 i씩 rightShift 하여 1(0b00000001)과 and 연산
+            int bit = (routineByte >> i) & 1;
+
+            // 만약 bit 값이 1이면 해당 요일에 루틴 존재
+            if (bit == 1) {
+                int dayValue = (i % 7) + 1;
+                routineDays.add(DayOfWeek.of(dayValue));
+            }
+        }
+        return routineDays;
+    }
+
+    /**
+     * List<DayOfWeek>를 Byte로 변환
+     * @param routineDays : DayOfWeek 리스트
+     * @return Byte 루틴
+     * MON(1) : 0000 0001
+     * TUE(2) : 0000 0010
+     * ...
+     * SUN(7) : 0100 0000
+     */
+    public static Byte routineDaysToByte(List<DayOfWeek> routineDays) {
+        int routineByte = 0;
+
+        for (DayOfWeek day : routineDays) {
+            int bit = 1;
+            int dayValue = day.getValue();
+            routineByte = routineByte | (bit << (dayValue - 1));
+        }
+
+        return (byte) routineByte;
+    }
+}

--- a/src/main/java/com/planit/planit/task/enums/RoutineDay.java
+++ b/src/main/java/com/planit/planit/task/enums/RoutineDay.java
@@ -1,5 +1,0 @@
-package com.planit.planit.task.enums;
-
-public enum RoutineDay {
-    MON, TUE, WED, THU, FRI, SAT, SUN
-}

--- a/src/main/java/com/planit/planit/task/service/TaskCommandServiceImpl.java
+++ b/src/main/java/com/planit/planit/task/service/TaskCommandServiceImpl.java
@@ -12,6 +12,7 @@ import com.planit.planit.plan.Plan;
 import com.planit.planit.plan.repository.PlanRepository;
 import com.planit.planit.task.Task;
 import com.planit.planit.task.association.CompletedTask;
+import com.planit.planit.task.converter.RoutineConverter;
 import com.planit.planit.task.repository.CompletedTaskRepository;
 import com.planit.planit.task.repository.TaskRepository;
 import com.planit.planit.web.dto.task.TaskRequestDTO;
@@ -106,7 +107,7 @@ public class TaskCommandServiceImpl implements TaskCommandService {
         // 루틴 설정
         task.setRoutine(
                 routineDTO.getTaskType(),
-                routineDTO.getRoutineDay(),
+                RoutineConverter.routineDaysToByte(routineDTO.getRoutineDay()),
                 routineDTO.getRoutineTime()
         );
 
@@ -158,7 +159,10 @@ public class TaskCommandServiceImpl implements TaskCommandService {
         }
 
         // 오늘 루틴에 해당하는 작업인지 확인
-        if (!task.getRoutineDay().equals(today.getDayOfWeek())) {
+        boolean isTodayRoutine = RoutineConverter.byteToRoutineDays(task.getRoutine())
+                .stream().anyMatch(day -> day.equals(today.getDayOfWeek()));
+
+        if (!isTodayRoutine) {
             throw new TaskHandler(TaskErrorStatus.NOT_ROUTINE_OF_TODAY);
         }
 

--- a/src/main/java/com/planit/planit/web/dto/task/TaskRequestDTO.java
+++ b/src/main/java/com/planit/planit/web/dto/task/TaskRequestDTO.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
+import java.util.List;
 
 @Getter
 public class TaskRequestDTO {
@@ -19,7 +20,7 @@ public class TaskRequestDTO {
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     public static class RoutineDTO {
         private final TaskType taskType;
-        private final DayOfWeek routineDay;
+        private final List<DayOfWeek> routineDay;
 
         @Schema(type = "string", pattern = "HH:mm", example = "14:00")
         @JsonFormat(pattern = "HH:mm")

--- a/src/main/java/com/planit/planit/web/dto/task/TaskResponseDTO.java
+++ b/src/main/java/com/planit/planit/web/dto/task/TaskResponseDTO.java
@@ -29,7 +29,7 @@ public class TaskResponseDTO {
     public static class TaskRoutineDTO {
         private final Long taskId;
         private final TaskType taskType;
-        private final DayOfWeek routineDay;
+        private final List<DayOfWeek> routineDay;
         private final LocalTime routineTime;
     }
 

--- a/src/main/java/com/planit/planit/web/dto/task/converter/TaskConverter.java
+++ b/src/main/java/com/planit/planit/web/dto/task/converter/TaskConverter.java
@@ -3,6 +3,7 @@ package com.planit.planit.web.dto.task.converter;
 import com.planit.planit.plan.Plan;
 import com.planit.planit.task.Task;
 import com.planit.planit.task.association.CompletedTask;
+import com.planit.planit.task.converter.RoutineConverter;
 import com.planit.planit.web.dto.task.TaskResponseDTO;
 
 import java.time.LocalDate;
@@ -22,7 +23,7 @@ public class TaskConverter {
         return TaskResponseDTO.TaskRoutineDTO.builder()
                 .taskId(task.getId())
                 .taskType(task.getTaskType())
-                .routineDay(task.getRoutineDay())
+                .routineDay(RoutineConverter.byteToRoutineDays(task.getRoutine()))
                 .routineTime(task.getRoutineTime())
                 .build();
     }
@@ -32,7 +33,8 @@ public class TaskConverter {
                 // 삭제되지 않은 작업만 필터링
                 .filter(task -> task.getDeletedAt() == null)
                 // 오늘 루틴에 해당하는 작업만 필터링
-                .filter(task -> task.getRoutineDay().equals(today.getDayOfWeek()))
+                .filter(task -> RoutineConverter.byteToRoutineDays(task.getRoutine()).stream()
+                        .anyMatch(day -> day.equals(today.getDayOfWeek())))
                 // 오늘 완료된 작업이 있으면 true로 표시
                 .map(task -> {
                     List<Task> tasks = task.getCompletedTasks().stream()

--- a/src/test/java/com/planit/planit/task/repository/TaskRepositoryTest.java
+++ b/src/test/java/com/planit/planit/task/repository/TaskRepositoryTest.java
@@ -8,6 +8,7 @@ import com.planit.planit.plan.enums.PlanStatus;
 import com.planit.planit.plan.repository.PlanRepository;
 import com.planit.planit.task.Task;
 import com.planit.planit.task.association.CompletedTask;
+import com.planit.planit.task.converter.RoutineConverter;
 import com.planit.planit.task.enums.TaskType;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -185,14 +186,18 @@ class TaskRepositoryTest {
         task1 = taskRepository.save(task1);
 
         // when
-        task1.setRoutine(TaskType.SLOW, DayOfWeek.WEDNESDAY, LocalTime.of(13,0));
+        task1.setRoutine(
+                TaskType.SLOW,
+                RoutineConverter.routineDaysToByte(List.of(DayOfWeek.WEDNESDAY)),
+                LocalTime.of(13,0)
+        );
 
         // then
         Task result = taskRepository.findById(task1.getId()).get();
         assertNotNull(result);
         assertThat(result.getId()).isEqualTo(task1.getId());
         assertThat(result.getTaskType()).isEqualTo(TaskType.SLOW);
-        assertThat(result.getRoutineDay()).isEqualTo(DayOfWeek.WEDNESDAY);
+        assertThat(result.getRoutine()).isEqualTo(RoutineConverter.routineDaysToByte(List.of(DayOfWeek.WEDNESDAY)));
         assertThat(result.getRoutineTime()).isEqualTo(LocalTime.of(13, 0));
     }
 

--- a/src/test/java/com/planit/planit/task/service/TaskCommandServiceTest.java
+++ b/src/test/java/com/planit/planit/task/service/TaskCommandServiceTest.java
@@ -11,6 +11,7 @@ import com.planit.planit.plan.enums.PlanStatus;
 import com.planit.planit.plan.repository.PlanRepository;
 import com.planit.planit.task.Task;
 import com.planit.planit.task.association.CompletedTask;
+import com.planit.planit.task.converter.RoutineConverter;
 import com.planit.planit.task.enums.TaskType;
 import com.planit.planit.task.repository.CompletedTaskRepository;
 import com.planit.planit.task.repository.TaskRepository;
@@ -229,7 +230,7 @@ class TaskCommandServiceTest {
 
         TaskRequestDTO.RoutineDTO routineDTO = TaskRequestDTO.RoutineDTO.builder()
                 .taskType(TaskType.SLOW)
-                .routineDay(DayOfWeek.SATURDAY)
+                .routineDay(List.of(DayOfWeek.SATURDAY))
                 .routineTime(LocalTime.of(14, 0))
                 .build();
 
@@ -240,7 +241,7 @@ class TaskCommandServiceTest {
         assertNotNull(result);
         assertThat(result.getTaskId()).isEqualTo(1L);
         assertThat(result.getTaskType()).isEqualTo(TaskType.SLOW);
-        assertThat(result.getRoutineDay()).isEqualTo(DayOfWeek.SATURDAY);
+        assertThat(result.getRoutineDay()).isEqualTo(List.of(DayOfWeek.SATURDAY));
         assertThat(result.getRoutineTime()).isEqualTo(LocalTime.of(14, 0));
     }
 
@@ -253,7 +254,7 @@ class TaskCommandServiceTest {
 
         TaskRequestDTO.RoutineDTO routineDTO = TaskRequestDTO.RoutineDTO.builder()
                 .taskType(TaskType.SLOW)
-                .routineDay(DayOfWeek.SATURDAY)
+                .routineDay(List.of(DayOfWeek.SATURDAY))
                 .routineTime(LocalTime.of(14, 0))
                 .build();
 
@@ -279,7 +280,7 @@ class TaskCommandServiceTest {
 
         TaskRequestDTO.RoutineDTO routineDTO = TaskRequestDTO.RoutineDTO.builder()
                 .taskType(TaskType.SLOW)
-                .routineDay(DayOfWeek.SATURDAY)
+                .routineDay(List.of(DayOfWeek.SATURDAY))
                 .routineTime(LocalTime.of(14, 0))
                 .build();
 
@@ -359,7 +360,11 @@ class TaskCommandServiceTest {
                 .plan(plan)
                 .build();
 
-        task.setRoutine(TaskType.ALL, LocalDate.of(2025, 1, 3).getDayOfWeek(), null);
+        task.setRoutine(
+                TaskType.ALL,
+                RoutineConverter.routineDaysToByte(List.of(LocalDate.of(2025, 1, 3).getDayOfWeek())),
+                null
+        );
 
         completedTask = CompletedTask.builder()
                 .task(task)
@@ -404,7 +409,10 @@ class TaskCommandServiceTest {
                 .plan(plan)
                 .build();
 
-        task.setRoutine(TaskType.ALL, LocalDate.of(2025, 1, 3).getDayOfWeek(), null);
+        task.setRoutine(TaskType.ALL,
+                RoutineConverter.routineDaysToByte(List.of(LocalDate.of(2025, 1, 3).getDayOfWeek())),
+                null
+        );
 
         completedTask = CompletedTask.builder()
                 .task(task)
@@ -445,7 +453,11 @@ class TaskCommandServiceTest {
                 .plan(plan)
                 .build();
 
-        task.setRoutine(TaskType.ALL, LocalDate.of(2025, 1, 4).getDayOfWeek(), null);
+        task.setRoutine(
+                TaskType.ALL,
+                RoutineConverter.routineDaysToByte(List.of(LocalDate.of(2025, 1, 4).getDayOfWeek())),
+                null
+        );
 
         completedTask = CompletedTask.builder()
                 .task(task)
@@ -490,7 +502,11 @@ class TaskCommandServiceTest {
                 .plan(plan)
                 .build();
 
-        task.setRoutine(TaskType.ALL, LocalDate.of(2025, 1, 5).getDayOfWeek(), null);
+        task.setRoutine(
+                TaskType.ALL,
+                RoutineConverter.routineDaysToByte(List.of(LocalDate.of(2025, 1, 5).getDayOfWeek())),
+                null
+        );
 
         completedTask = CompletedTask.builder()
                 .task(task)
@@ -562,7 +578,10 @@ class TaskCommandServiceTest {
                 .plan(plan)
                 .build();
 
-        task.setRoutine(TaskType.ALL, LocalDate.of(2025, 1, 5).getDayOfWeek(), null);
+        task.setRoutine(
+                TaskType.ALL,
+                RoutineConverter.routineDaysToByte(List.of(LocalDate.of(2025, 1, 5).getDayOfWeek())),
+                null);
 
         completedTask = CompletedTask.builder()
                 .task(task)

--- a/src/test/java/com/planit/planit/task/service/TaskQueryServiceTest.java
+++ b/src/test/java/com/planit/planit/task/service/TaskQueryServiceTest.java
@@ -7,6 +7,7 @@ import com.planit.planit.plan.Plan;
 import com.planit.planit.plan.enums.PlanStatus;
 import com.planit.planit.plan.repository.PlanRepository;
 import com.planit.planit.task.Task;
+import com.planit.planit.task.converter.RoutineConverter;
 import com.planit.planit.task.enums.TaskType;
 import com.planit.planit.task.repository.TaskRepository;
 import com.planit.planit.web.dto.task.TaskResponseDTO;
@@ -22,6 +23,7 @@ import org.mockito.quality.Strictness;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -102,7 +104,7 @@ class TaskQueryServiceTest {
 
         task.setRoutine(
                 TaskType.PASSIONATE,
-                DayOfWeek.FRIDAY,
+                RoutineConverter.routineDaysToByte(List.of(DayOfWeek.FRIDAY)),
                 LocalTime.of(19, 0)
         );
 
@@ -115,7 +117,7 @@ class TaskQueryServiceTest {
         assertNotNull(result);
         assertThat(result.getTaskId()).isEqualTo(1L);
         assertThat(result.getTaskType()).isEqualTo(TaskType.PASSIONATE);
-        assertThat(result.getRoutineDay()).isEqualTo(DayOfWeek.FRIDAY);
+        assertThat(result.getRoutineDay()).isEqualTo(List.of(DayOfWeek.FRIDAY));
         assertThat(result.getRoutineTime()).isEqualTo(LocalTime.of(19, 0));
     }
 
@@ -144,7 +146,7 @@ class TaskQueryServiceTest {
 
         task.setRoutine(
                 TaskType.PASSIONATE,
-                DayOfWeek.FRIDAY,
+                RoutineConverter.routineDaysToByte(List.of(DayOfWeek.FRIDAY)),
                 LocalTime.of(19, 0)
         );
 


### PR DESCRIPTION
## 연관된 이슈

> 이슈 번호를 작성해주세요

- #81 

<br>

## 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- 기존의 routineDay (enum) 필드 삭제 -> routine (tinyint) 필드 추가
- 각 요일을 1비트에 매핑하여 관리 (RoutineConverter 참조)
  - 월요일 : 0000 0001 = 1
  - 화요일 : 0000 0010 = 2
  - ...
  - 일요일 : 0100 0000 = 127
 
** 유효한 정수 범위 : 0-127
** 클라이언트 측에서는 RequestDTO와 ResponseDTO에서 루틴이 DayOfWeek -> List<DayOfWeek>로 바뀐 것 외 차이없음

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 해당 이슈는 배포 서버에 우선 반영되었습니다. 확인해주셔서 감사합니당 !!
