### PR TITLE
[HOTFIX] Hotfix/0.4.2 -> Develop

### DIFF
--- a/src/main/java/com/planit/planit/common/api/ApiResponse.java
+++ b/src/main/java/com/planit/planit/common/api/ApiResponse.java
@@ -7,6 +7,7 @@ import com.planit.planit.common.api.general.status.ErrorResponse;
 import com.planit.planit.common.api.general.status.ErrorStatus;
 import com.planit.planit.common.api.general.status.SuccessResponse;
 import com.planit.planit.common.api.general.status.SuccessStatus;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.Getter;
 
 @Getter
@@ -41,7 +42,7 @@ public class ApiResponse<T>  {
 
     // Failure
     public static <T> ApiResponse<T> onFailure(ErrorResponse status) {
-        return new ApiResponse<>(false, status.getCode(), status.getMessage(), null);
+        return new ApiResponse<>(status);
     }
 
     // Failure with Data
@@ -49,13 +50,13 @@ public class ApiResponse<T>  {
         return new ApiResponse<>(false, status.getCode(), status.getMessage(), data);
     }
 
-    public ApiResponse(SuccessResponse response) {
+    private ApiResponse(SuccessResponse response) {
         this.isSuccess = true;
         this.code = response.getCode();
         this.message = response.getMessage();
     }
 
-    public ApiResponse(ErrorResponse response) {
+    private ApiResponse(ErrorResponse response) {
         this.isSuccess = false;
         this.code = response.getCode();
         this.message = response.getMessage();

--- a/src/main/java/com/planit/planit/common/api/ApiResponse.java
+++ b/src/main/java/com/planit/planit/common/api/ApiResponse.java
@@ -4,11 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.planit.planit.common.api.general.status.ErrorResponse;
-import com.planit.planit.common.api.general.status.ErrorStatus;
 import com.planit.planit.common.api.general.status.SuccessResponse;
-import com.planit.planit.common.api.general.status.SuccessStatus;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.Getter;
+import org.springframework.http.ResponseEntity;
 
 @Getter
 @JsonPropertyOrder({"isSuccess", "code", "message", "result"})
@@ -30,24 +28,32 @@ public class ApiResponse<T>  {
     }
 
     // Success
-    public static ApiResponse<Void> onSuccess(SuccessResponse status) {
-        return new ApiResponse<>(status);
+    public static ResponseEntity<ApiResponse<Void>> onSuccess(SuccessResponse status) {
+        return ResponseEntity
+                .status(status.getSuccessStatus().value())
+                .body(new ApiResponse<>(status));
     }
 
     // Success with Data
-    public static <T> ApiResponse<T> onSuccess(SuccessResponse status, T data) {
-        return new ApiResponse<>(true, status.getCode(), status.getMessage(), data);
+    public static <T> ResponseEntity<ApiResponse<T>> onSuccess(SuccessResponse status, T data) {
+        return ResponseEntity
+                .status(status.getSuccessStatus().value())
+                .body(new ApiResponse<>(true, status.getCode(), status.getMessage(), data));
 
     }
 
     // Failure
-    public static <T> ApiResponse<T> onFailure(ErrorResponse status) {
-        return new ApiResponse<>(status);
+    public static ResponseEntity<ApiResponse<Void>> onFailure(ErrorResponse status) {
+        return ResponseEntity
+                .status(status.getErrorStatus().value())
+                .body(new ApiResponse<>(status));
     }
 
     // Failure with Data
-    public static <T> ApiResponse<T> onFailure(ErrorResponse status, T data) {
-        return new ApiResponse<>(false, status.getCode(), status.getMessage(), data);
+    public static <T> ResponseEntity<ApiResponse<T>> onFailure(ErrorResponse status, T data) {
+        return ResponseEntity
+                .status(status.getErrorStatus().value())
+                .body(new ApiResponse<>(false, status.getCode(), status.getMessage(), data));
     }
 
     private ApiResponse(SuccessResponse response) {

--- a/src/main/java/com/planit/planit/common/api/ExceptionAdvice.java
+++ b/src/main/java/com/planit/planit/common/api/ExceptionAdvice.java
@@ -4,6 +4,7 @@ import com.planit.planit.common.api.general.GeneralException;
 import com.planit.planit.common.api.general.status.ErrorStatus;
 import io.jsonwebtoken.JwtException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -19,7 +20,7 @@ public class ExceptionAdvice {
      * @return ApiResponse - GeneralException
      */
     @ExceptionHandler(GeneralException.class)
-    public ApiResponse<String> baseExceptionHandle(GeneralException exception) {
+    public ResponseEntity<ApiResponse<Void>> handleGeneralException(GeneralException exception) {
         log.error("COMM:CTRL:GENERAL:::GeneralException msg({})", exception.getMessage());
         return ApiResponse.onFailure(exception.getStatus());
     }
@@ -30,7 +31,7 @@ public class ExceptionAdvice {
      * @return ApiResponse - INTERNAL_SERVER_ERROR
      */
     @ExceptionHandler(Exception.class)
-    public ApiResponse<String> exceptionHandle(Exception exception) {
+    public ResponseEntity<ApiResponse<String>> handleException(Exception exception) {
         log.error("COMM:CTRL:____:::Exception msg({})", exception.getMessage());
         return ApiResponse.onFailure(ErrorStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
     }
@@ -41,7 +42,7 @@ public class ExceptionAdvice {
      * @return ApiResponse - BAD_REQUEST
      */
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ApiResponse<String> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException exception) {
+    public ResponseEntity<ApiResponse<String>> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException exception) {
         log.error("ARG_:CTRL:MISMATCH:::MethodArgumentTypeMismatchException msg({})", exception.getMessage());
         return ApiResponse.onFailure(ErrorStatus.BAD_REQUEST, exception.getMessage());
     }
@@ -52,7 +53,7 @@ public class ExceptionAdvice {
      * @return ApiResponse - FORBIDDEN
      */
     @ExceptionHandler(JwtException.class)
-    public ApiResponse<String> exceptionHandle(JwtException exception) {
+    public ResponseEntity<ApiResponse<String>> handleJwtException(JwtException exception) {
         log.error("JWT_:CTRL:INVALID:::Exception msg({})", exception.getMessage());
         return ApiResponse.onFailure(ErrorStatus.FORBIDDEN, exception.getMessage());
     }

--- a/src/main/java/com/planit/planit/common/api/member/status/MemberErrorStatus.java
+++ b/src/main/java/com/planit/planit/common/api/member/status/MemberErrorStatus.java
@@ -8,6 +8,7 @@ public enum MemberErrorStatus implements ErrorResponse {
     // 회원
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "회원을 찾을 수 없습니다."),
     MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER4002", "이미 가입된 회원입니다."),
+    MEMBER_ALREADY_SIGN_UP_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER4003", "약관 동의가 완료된 회원입니다."),
 
     // 길티프리
     GUILTY_FREE_ACTIVATION_FORBIDDEN(HttpStatus.BAD_REQUEST, "MEMBER4010", "길티프리는 주 1회만 활성화할 수 있습니다."),

--- a/src/main/java/com/planit/planit/member/service/MemberService.java
+++ b/src/main/java/com/planit/planit/member/service/MemberService.java
@@ -4,8 +4,9 @@ import com.planit.planit.member.association.SignedMember;
 import com.planit.planit.member.enums.SignType;
 import com.planit.planit.web.dto.member.MemberInfoResponseDTO;
 import com.planit.planit.web.dto.member.MemberResponseDTO;
-import com.planit.planit.web.dto.member.term.TermDTO;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 public interface MemberService {
@@ -16,7 +17,7 @@ public interface MemberService {
 
     MemberResponseDTO.ConsecutiveDaysDTO getConsecutiveDays(Long memberId);
 
-    void completeTermsAgreement(String signUpToken, TermDTO.AgreementRequest agreementRequest);
+    LocalDateTime completeTermsAgreement(String signUpToken);
 
     MemberInfoResponseDTO getMemberInfo(Long memberId);
 }

--- a/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
@@ -110,6 +110,11 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
 
+        // 이미 약관 동의가 완료된 경우 예외 처리
+        if (member.isSignUpCompleted()) {
+            throw new MemberHandler(MemberErrorStatus.MEMBER_ALREADY_SIGN_UP_COMPLETED);
+        }
+
         // Term 저장
         LocalDateTime now = LocalDateTime.now();
         Term term = Term.builder()

--- a/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
@@ -17,12 +17,12 @@ import com.planit.planit.member.repository.NotificationRepository;
 import com.planit.planit.member.repository.TermRepository;
 import com.planit.planit.web.dto.member.MemberInfoResponseDTO;
 import com.planit.planit.web.dto.member.MemberResponseDTO;
-import com.planit.planit.web.dto.member.term.TermDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Slf4j
@@ -103,7 +103,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public void completeTermsAgreement(String signUpToken, TermDTO.AgreementRequest agreementRequest) {
+    public LocalDateTime completeTermsAgreement(String signUpToken) {
 
         // 회원가입용 토큰 검증
         Long memberId = jwtProvider.validateSignUpTokenAndGetId(signUpToken);
@@ -111,13 +111,14 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
 
         // Term 저장
+        LocalDateTime now = LocalDateTime.now();
         Term term = Term.builder()
                 .member(member)
-                .termOfUse(agreementRequest.getTermOfUse())
-                .termOfPrivacy(agreementRequest.getTermOfPrivacy())
-                .termOfInfo(agreementRequest.getTermOfInfo())
-                .thirdPartyAdConsent(agreementRequest.getThirdPartyAdConsent())
-                .overFourteen(agreementRequest.getOverFourteen())
+                .termOfUse(now)
+                .termOfPrivacy(now)
+                .termOfInfo(now)
+                .thirdPartyAdConsent(now)
+                .overFourteen(now)
                 .build();
         termRepository.save(term);
 
@@ -127,6 +128,7 @@ public class MemberServiceImpl implements MemberService {
 
         // 저장
         log.info("✅ 약관 동의 성공 - id: {}, email: {}", member.getId(), member.getEmail());
+        return now;
     }
 
     @Override

--- a/src/main/java/com/planit/planit/web/controller/AuthController.java
+++ b/src/main/java/com/planit/planit/web/controller/AuthController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,17 +32,22 @@ public class AuthController {
 
     @Operation(summary = "[AUTH] idToken 기반 로그인/회원가입", description = "모바일 앱에서 받은 idToken을 검증하여 로그인 또는 회원가입을 처리합니다.")
     @PostMapping("/sign-in")
-    public ApiResponse<OAuthLoginDTO.LoginResponse> signIn(@RequestBody OAuthLoginDTO.LoginRequest loginRequest) {
+    public ResponseEntity<ApiResponse<OAuthLoginDTO.LoginResponse>> signIn(
+            @RequestBody OAuthLoginDTO.LoginRequest loginRequest
+    ) {
         OAuthLoginDTO.LoginResponse loginResponse = authService.signIn(loginRequest);
         log.info("✅ 로그인 or 회원가입 성공 - id: {}, email: {}, name: {}, isNewMember: {}, 약관 동의여부: {}",
-                loginResponse.getId(), loginResponse.getEmail(), loginResponse.getName(), loginResponse.isNewMember(), loginResponse.isSignUpCompleted());
+                 loginResponse.getId(), loginResponse.getEmail(), loginResponse.getName(),
+                 loginResponse.isNewMember(), loginResponse.isSignUpCompleted());
         return ApiResponse.onSuccess(MemberSuccessStatus.SIGN_IN_SUCCESS, loginResponse);
     }
 
     @Operation(summary = "[AUTH] 로그아웃", description = "사용자 로그아웃을 처리하고 토큰을 블랙리스트에 추가합니다.")
     @SecurityRequirement(name = "accessToken")
     @PostMapping("/sign-out")
-    public ApiResponse<Void> signOut(@AuthenticationPrincipal UserPrincipal principal, HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<Void>> signOut(
+            @AuthenticationPrincipal UserPrincipal principal, HttpServletRequest request
+    ) {
         String authHeader = request.getHeader("Authorization");
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             String accessToken = authHeader.substring("Bearer ".length());
@@ -53,7 +59,9 @@ public class AuthController {
 
     @Operation(summary = "[AUTH] 토큰 리프레시", description = "사용자 리프레시 토큰을 초기화합니다.")
     @PostMapping("/refresh")
-    public ApiResponse<TokenRefreshDTO.Response> refreshToken(@RequestBody TokenRefreshDTO.Request request) {
+    public ResponseEntity<ApiResponse<TokenRefreshDTO.Response>> refreshToken(
+            @RequestBody TokenRefreshDTO.Request request
+    ) {
         TokenRefreshDTO.Response response = authService.refreshAccessToken(request.getRefreshToken());
         return ApiResponse.onSuccess(REFRESH_SUCCESS, response);
     }

--- a/src/main/java/com/planit/planit/web/controller/GuiltyFreeController.java
+++ b/src/main/java/com/planit/planit/web/controller/GuiltyFreeController.java
@@ -9,6 +9,7 @@ import com.planit.planit.web.dto.member.guiltyfree.GuiltyFreeResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,29 +23,32 @@ public class GuiltyFreeController {
 
     @Operation(summary = "[GUILTY-FREE] 길티프리 활성화하기")
     @PatchMapping("/guilty-free")
-    public ApiResponse<GuiltyFreeResponseDTO.GuiltyFreeActivationDTO> activateGuiltyFree(
+    public ResponseEntity<ApiResponse<GuiltyFreeResponseDTO.GuiltyFreeActivationDTO>> activateGuiltyFree(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam GuiltyFreeReason reason
     ) {
-        GuiltyFreeResponseDTO.GuiltyFreeActivationDTO guiltyFreeActivationDTO = guiltyFreeService.activateGuiltyFree(principal.getId(), reason);
+        GuiltyFreeResponseDTO.GuiltyFreeActivationDTO guiltyFreeActivationDTO = guiltyFreeService
+                .activateGuiltyFree(principal.getId(), reason);
         return ApiResponse.onSuccess(MemberSuccessStatus.GUILTY_FREE_SET, guiltyFreeActivationDTO);
     }
 
     @Operation(summary = "[GUILTY-FREE] 길티프리 활성일 조회하기")
     @GetMapping("/guilty-free")
-    public ApiResponse<GuiltyFreeResponseDTO.GuiltyFreeStatusDTO> getGuiltyFreeStatus(
+    public ResponseEntity<ApiResponse<GuiltyFreeResponseDTO.GuiltyFreeStatusDTO>> getGuiltyFreeStatus(
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        GuiltyFreeResponseDTO.GuiltyFreeStatusDTO guiltyFreeActivationDTO = guiltyFreeService.getGuiltyFreeStatus(principal.getId());
+        GuiltyFreeResponseDTO.GuiltyFreeStatusDTO guiltyFreeActivationDTO = guiltyFreeService
+                .getGuiltyFreeStatus(principal.getId());
         return ApiResponse.onSuccess(MemberSuccessStatus.GUILTY_FREE_FOUND, guiltyFreeActivationDTO);
     }
 
     @Operation(summary = "[GUILTY-FREE] 길티프리 사유 목록 조회하기")
     @GetMapping("/guilty-free/list")
-    public ApiResponse<GuiltyFreeResponseDTO.GuiltyFreeReasonListDTO> getGuiltyFreeReasons(
+    public ResponseEntity<ApiResponse<GuiltyFreeResponseDTO.GuiltyFreeReasonListDTO>> getGuiltyFreeReasons(
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        GuiltyFreeResponseDTO.GuiltyFreeReasonListDTO guiltyFreeReasonListDTO = guiltyFreeService.getGuiltyFreeReasons(principal.getId());
+        GuiltyFreeResponseDTO.GuiltyFreeReasonListDTO guiltyFreeReasonListDTO = guiltyFreeService
+                .getGuiltyFreeReasons(principal.getId());
         return ApiResponse.onSuccess(MemberSuccessStatus.GUILTY_FREE_REASON_LIST_FOUND, guiltyFreeReasonListDTO);
     }
 }

--- a/src/main/java/com/planit/planit/web/controller/MemberController.java
+++ b/src/main/java/com/planit/planit/web/controller/MemberController.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -47,7 +48,7 @@ public class MemberController {
                        테스트시 필드에 Authorization을 작성하지 않고 스웨거의 Authorization에 넣어야 합니다.
                """)
     @PostMapping("/terms")
-    public ApiResponse<String> agreeTerms(
+    public ResponseEntity<ApiResponse<String>> agreeTerms(
             @RequestHeader(value = "Authorization", required = false) String signUpToken
     ) {
         LocalDateTime termAgreeDate = memberService.completeTermsAgreement(signUpToken);
@@ -56,7 +57,7 @@ public class MemberController {
 
     @Operation(summary = "[TERM] 모든 약관 URL 조회", description = "최신 약관 HTML 파일들의 URL과 버전을 반환합니다.")
     @GetMapping("/terms")
-    public ApiResponse<Map<String, Map<String, String>>> getTermsUrls() {
+    public ResponseEntity<ApiResponse<Map<String, Map<String, String>>>> getTermsUrls() {
         Map<String, Map<String, String>> termsInfo = termService.getAllTermsUrls();
         log.info("✅ 약관 URL 정보 조회 성공: {}", termsInfo);
         return ApiResponse.onSuccess(MemberSuccessStatus.TERMS_URLS_FOUND, termsInfo);
@@ -65,7 +66,7 @@ public class MemberController {
 
     @Operation(summary = "[MEMBER] 연속일 조회하기")
     @GetMapping("/consecutive-days")
-    public ApiResponse<MemberResponseDTO.ConsecutiveDaysDTO> getConsecutiveDays(
+    public ResponseEntity<ApiResponse<MemberResponseDTO.ConsecutiveDaysDTO>> getConsecutiveDays(
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         MemberResponseDTO.ConsecutiveDaysDTO consecutiveDaysDTO = memberService.getConsecutiveDays(principal.getId());
@@ -75,7 +76,7 @@ public class MemberController {
     // 오늘의 할 일 알림 ON/OFF
     @Operation(summary = "[NOTIFICATION] 오늘의 할 일 알림 설정 변경", description = "오늘의 할 일 알림 ON/OFF를 설정합니다.")
     @PatchMapping("/notification-settings/daily-task")
-    public ApiResponse<Void> updateDailyTask(
+    public ResponseEntity<ApiResponse<Void>> updateDailyTask(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody NotificationDTO.ToggleRequest request
     ) {
@@ -86,7 +87,7 @@ public class MemberController {
     // 길티프리 모드 알림 ON/OFF
     @Operation(summary = "[NOTIFICATION] 길티프리 모드 알림 설정 변경", description = "길티프리 모드 알림 ON/OFF를 설정합니다.")
     @PatchMapping("/notification-settings/guilty-free")
-    public ApiResponse<Void> updateGuiltFree(
+    public ResponseEntity<ApiResponse<Void>> updateGuiltFree(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody NotificationDTO.ToggleRequest request
     ) {
@@ -97,7 +98,7 @@ public class MemberController {
     // 전체 알림 설정 조회
     @Operation(summary = "[NOTIFICATION] 전체 알림 설정 조회", description = "사용자의 전체 알림 설정 상태를 조회합니다.")
     @GetMapping("/notification-settings")
-    public ApiResponse<NotificationDTO.Response> getNotificationSetting(
+    public ResponseEntity<ApiResponse<NotificationDTO.Response>> getNotificationSetting(
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         NotificationDTO.Response response = notificationService.getMyNotificationSetting(principal.getId());
@@ -108,7 +109,7 @@ public class MemberController {
     @Operation(summary = "[MEMBER] 내 정보 조회", description = "로그인한 사용자의 정보를 조회합니다.")
     @SecurityRequirement(name = "accessToken")
     @GetMapping("")
-    public ApiResponse<MemberInfoResponseDTO> getMyInfo(
+    public ResponseEntity<ApiResponse<MemberInfoResponseDTO>> getMyInfo(
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         MemberInfoResponseDTO response = memberService.getMemberInfo(principal.getId());
@@ -118,7 +119,7 @@ public class MemberController {
     @Operation(summary = "[FCM] FCM 토큰 저장 또는 갱신", description = "로그인한 사용자의 FCM 토큰을 저장하거나 갱신합니다.")
     @SecurityRequirement(name = "accessToken")
     @PostMapping("/me/fcm-token")
-    public ApiResponse<Void> saveOrUpdateFcmToken(
+    public ResponseEntity<ApiResponse<Void>> saveOrUpdateFcmToken(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody FcmTokenDTO.SaveRequest request
     ) {
@@ -132,7 +133,7 @@ public class MemberController {
     @Operation(summary = "[FCM] 내 FCM 토큰 조회", description = "로그인한 사용자의 저장된 FCM 토큰을 조회합니다.")
     @SecurityRequirement(name = "accessToken")
     @GetMapping("/me/fcm-token")
-    public ApiResponse<FcmTokenDTO.Response> getMyFcmToken(
+    public ResponseEntity<ApiResponse<FcmTokenDTO.Response>> getMyFcmToken(
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         String token = fcmTokenService.getTokenByMemberId(principal.getId()).orElse(null);
@@ -142,7 +143,7 @@ public class MemberController {
     @Operation(summary = "[FCM] 내 FCM 토큰 삭제", description = "로그인한 사용자의 FCM 토큰을 삭제합니다.")
     @SecurityRequirement(name = "accessToken")
     @DeleteMapping("/me/fcm-token")
-    public ApiResponse<Void> deleteMyFcmToken(@AuthenticationPrincipal UserPrincipal principal) {
+    public ResponseEntity<ApiResponse<Void>> deleteMyFcmToken(@AuthenticationPrincipal UserPrincipal principal) {
         fcmTokenService.deleteTokensByMemberId(principal.getId());
         log.info("🗑️ FCM 토큰 삭제 완료 - memberId: {}", principal.getId());
         return ApiResponse.onSuccess(MemberSuccessStatus.FCM_TOKEN_DELETED);

--- a/src/main/java/com/planit/planit/web/controller/MemberController.java
+++ b/src/main/java/com/planit/planit/web/controller/MemberController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 @Slf4j
@@ -43,15 +44,14 @@ public class MemberController {
     @Operation(summary = "[TERM] 약관 동의 완료",
                description = """
                        사용자가 약관에 동의했음을 저장하고 isSignUpCompleted를 true로 갱신합니다.
-                       테스트시 필드에 Authorization을 작성하지 않고 스웨거의 Authorization에 넣어야 합니다. (Bearer prefix 필요)
+                       테스트시 필드에 Authorization을 작성하지 않고 스웨거의 Authorization에 넣어야 합니다.
                """)
     @PostMapping("/terms")
-    public ApiResponse<Void> agreeTerms(
-            @RequestHeader(value = "Authorization", required = false) String signUpToken,
-            @RequestBody TermDTO.AgreementRequest agreementRequest
+    public ApiResponse<String> agreeTerms(
+            @RequestHeader(value = "Authorization", required = false) String signUpToken
     ) {
-        memberService.completeTermsAgreement(signUpToken, agreementRequest);
-        return ApiResponse.onSuccess(MemberSuccessStatus.TERM_AGREEMENT_COMPLETED, null);
+        LocalDateTime termAgreeDate = memberService.completeTermsAgreement(signUpToken);
+        return ApiResponse.onSuccess(MemberSuccessStatus.TERM_AGREEMENT_COMPLETED, termAgreeDate.toString());
     }
 
     @Operation(summary = "[TERM] 모든 약관 URL 조회", description = "최신 약관 HTML 파일들의 URL과 버전을 반환합니다.")

--- a/src/main/java/com/planit/planit/web/controller/PlanController.java
+++ b/src/main/java/com/planit/planit/web/controller/PlanController.java
@@ -11,6 +11,7 @@ import com.planit.planit.web.dto.plan.PlanResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,7 +26,7 @@ public class PlanController {
 
     @Operation(summary = "[PLAN] 플랜 생성하기")
     @PostMapping("/plans")
-    public ApiResponse<PlanResponseDTO.PlanMetaDTO> createPlan(
+    public ResponseEntity<ApiResponse<PlanResponseDTO.PlanMetaDTO>> createPlan(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody PlanRequestDTO.PlanDTO planDTO
     ) {
@@ -36,7 +37,7 @@ public class PlanController {
 
     @Operation(summary = "[PLAN] 플랜 수정하기")
     @PatchMapping("/plans/{planId}")
-    public ApiResponse<PlanResponseDTO.PlanMetaDTO> updatePlan(
+    public ResponseEntity<ApiResponse<PlanResponseDTO.PlanMetaDTO>> updatePlan(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long planId,
             @RequestBody PlanRequestDTO.PlanDTO planDTO
@@ -48,7 +49,7 @@ public class PlanController {
 
     @Operation(summary = "[PLAN] 플랜 완료(아카이빙) 하기")
     @PatchMapping("/plans/{planId}/complete")
-    public ApiResponse<PlanResponseDTO.PlanMetaDTO> completePlan(
+    public ResponseEntity<ApiResponse<PlanResponseDTO.PlanMetaDTO>> completePlan(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long planId
     ) {
@@ -59,7 +60,7 @@ public class PlanController {
 
     @Operation(summary = "[PLAN] 플랜 중단하기")
     @PatchMapping("/plans/{planId}/pause")
-    public ApiResponse<PlanResponseDTO.PlanMetaDTO> pausePlan(
+    public ResponseEntity<ApiResponse<PlanResponseDTO.PlanMetaDTO>> pausePlan(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long planId
     ) {
@@ -70,7 +71,7 @@ public class PlanController {
 
     @Operation(summary = "[PLAN] 플랜 삭제하기")
     @PatchMapping("/plans/{planId}/delete")
-    public ApiResponse<PlanResponseDTO.PlanMetaDTO> deletePlan(
+    public ResponseEntity<ApiResponse<PlanResponseDTO.PlanMetaDTO>> deletePlan(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long planId
     ) {
@@ -81,7 +82,7 @@ public class PlanController {
 
     @Operation(summary = "[PLAN] 오늘의 플랜 목록 조회하기")
     @GetMapping("/plans/today")
-    public ApiResponse<PlanResponseDTO.TodayPlanListDTO> getTodayPlans(@AuthenticationPrincipal UserPrincipal principal) {
+    public ResponseEntity<ApiResponse<PlanResponseDTO.TodayPlanListDTO>> getTodayPlans(@AuthenticationPrincipal UserPrincipal principal) {
         PlanResponseDTO.TodayPlanListDTO todayPlanListDTO = planQueryService.getTodayPlans(principal.getId());
         return ApiResponse.onSuccess(PlanSuccessStatus.TODAY_PLAN_LIST_FOUND, todayPlanListDTO);
     }
@@ -89,7 +90,7 @@ public class PlanController {
 
     @Operation(summary = "[PLAN] 플랜 목록 조회하기")
     @GetMapping("/plans")
-    public ApiResponse<PlanResponseDTO.PlanListDTO> getPlans(
+    public ResponseEntity<ApiResponse<PlanResponseDTO.PlanListDTO>> getPlans(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam PlanStatus planStatus
     ) {
@@ -99,7 +100,7 @@ public class PlanController {
 
     @Operation(summary = "[PLAN] 플랜 단건 조회하기")
     @GetMapping("/plans/{planId}")
-    public ApiResponse<PlanResponseDTO.PlanContentDTO> getPlan(
+    public ResponseEntity<ApiResponse<PlanResponseDTO.PlanContentDTO>> getPlan(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long planId
     ) {

--- a/src/main/java/com/planit/planit/web/controller/TaskController.java
+++ b/src/main/java/com/planit/planit/web/controller/TaskController.java
@@ -10,6 +10,7 @@ import com.planit.planit.web.dto.task.TaskResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,7 +27,7 @@ public class TaskController {
 
     @Operation(summary = "[TASK] 작업 생성하기")
     @PostMapping("/tasks")
-    public ApiResponse<TaskResponseDTO.TaskPreviewDTO> createTask(
+    public ResponseEntity<ApiResponse<TaskResponseDTO.TaskPreviewDTO>> createTask(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam Long planId,
             @RequestParam String title
@@ -37,29 +38,31 @@ public class TaskController {
 
     @Operation(summary = "[TASK] 작업명 수정하기")
     @PatchMapping("/tasks/{taskId}/title")
-    public ApiResponse<TaskResponseDTO.TaskPreviewDTO> updateTask(
+    public ResponseEntity<ApiResponse<TaskResponseDTO.TaskPreviewDTO>> updateTask(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long taskId,
             @RequestParam String title
     ) {
-        TaskResponseDTO.TaskPreviewDTO taskPreviewDTO = taskCommandService.updateTaskTitle(principal.getId(), taskId, title);
+        TaskResponseDTO.TaskPreviewDTO taskPreviewDTO = taskCommandService
+                .updateTaskTitle(principal.getId(), taskId, title);
         return ApiResponse.onSuccess(TaskSuccessStatus.TASK_TITLE_UPDATED, taskPreviewDTO);
     }
 
     @Operation(summary = "[TASK] 루틴 설정하기")
     @PatchMapping("/tasks/{taskId}/routine")
-    public ApiResponse<TaskResponseDTO.TaskRoutineDTO> setRoutine(
+    public ResponseEntity<ApiResponse<TaskResponseDTO.TaskRoutineDTO>> setRoutine(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long taskId,
             @RequestBody TaskRequestDTO.RoutineDTO routineDTO
     ) {
-        TaskResponseDTO.TaskRoutineDTO taskRoutineDTO = taskCommandService.setRoutine(principal.getId(), taskId, routineDTO);
+        TaskResponseDTO.TaskRoutineDTO taskRoutineDTO = taskCommandService
+                .setRoutine(principal.getId(), taskId, routineDTO);
         return ApiResponse.onSuccess(TaskSuccessStatus.TASK_ROUTINE_SET, taskRoutineDTO);
     }
 
     @Operation(summary = "[TASK] 작업 삭제하기")
     @PatchMapping("/tasks/{taskId}/delete")
-    public ApiResponse<TaskResponseDTO.TaskPreviewDTO> deleteTask(
+    public ResponseEntity<ApiResponse<TaskResponseDTO.TaskPreviewDTO>> deleteTask(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long taskId
     ) {
@@ -69,29 +72,31 @@ public class TaskController {
 
     @Operation(summary = "[TASK] 작업 완료하기")
     @PostMapping("/tasks/{taskId}/complete")
-    public ApiResponse<TaskResponseDTO.CompletedTaskDTO> completeTask(
+    public ResponseEntity<ApiResponse<TaskResponseDTO.CompletedTaskDTO>> completeTask(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long taskId
     ) {
         LocalDate today = LocalDate.now();
-        TaskResponseDTO.CompletedTaskDTO completedTaskDTO = taskCommandService.completeTask(principal.getId(), taskId, today);
+        TaskResponseDTO.CompletedTaskDTO completedTaskDTO = taskCommandService
+                .completeTask(principal.getId(), taskId, today);
         return ApiResponse.onSuccess(TaskSuccessStatus.TASK_COMPLETED, completedTaskDTO);
     }
 
     @Operation(summary = "[TASK] 작업 완료 취소하기")
     @PatchMapping("/tasks/{taskId}/cancel-completion")
-    public ApiResponse<TaskResponseDTO.CompletedTaskDTO> cancelTaskCompletion(
+    public ResponseEntity<ApiResponse<TaskResponseDTO.CompletedTaskDTO>> cancelTaskCompletion(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long taskId
     ) {
         LocalDate today = LocalDate.now();
-        TaskResponseDTO.CompletedTaskDTO completedTaskDTO = taskCommandService.cancelTaskCompletion(principal.getId(), taskId, today);
+        TaskResponseDTO.CompletedTaskDTO completedTaskDTO = taskCommandService
+                .cancelTaskCompletion(principal.getId(), taskId, today);
         return ApiResponse.onSuccess(TaskSuccessStatus.TASK_COMPLETION_CANCELED, completedTaskDTO);
     }
 
     @Operation(summary = "[TASK] 루틴 조회하기")
     @GetMapping("/tasks/{taskId}/routine")
-    public ApiResponse<TaskResponseDTO.TaskRoutineDTO> getCurrentRoutine(
+    public ResponseEntity<ApiResponse<TaskResponseDTO.TaskRoutineDTO>> getCurrentRoutine(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long taskId
     ) {

--- a/src/test/java/com/planit/planit/web/controller/auth/AuthControllerSignInTest.java
+++ b/src/test/java/com/planit/planit/web/controller/auth/AuthControllerSignInTest.java
@@ -62,10 +62,10 @@ class AuthControllerSignInTest {
                     .email("new@example.com")
                     .name("새 유저")
                     .accessToken("access-token-xyz")
-                    .refreshToken("refresh-token-xyz")
+                    .refreshToken(null)
                     .build();
             given(authService.signIn(any())).willReturn(loginResponse);
-            mockMvc.perform(post("/auth/sign-in")
+            mockMvc.perform(post("/planit/auth/sign-in")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(loginRequest)))
                     .andExpect(status().isOk());


### PR DESCRIPTION
## 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- 약관 동의 일시가 클라이언트 시각에서 **서버 시각 기준**으로 변경되었습니다.

- 약관 동의를 완료한 회원이 다시 약관 동의를 수행하려 하는 경우 **BAD_REQUEST**를 반환하도록 개선하였습니다.
- 커스텀 응답의 **상태코드가 항상 200으로 표시되는 문제를 해결**하였습니다.
  - SuccessResponse와 ErrorResponse에 지정한 HttpStatus.value()대로 응답이 반환됩니다.
  - 상태코드를 반영하기 위해 컨트롤러가 `ResponseEntity<ApiResponse<>>`를 반환하도록 변경하였습니다.