### PR TITLE
[PL-186] [feat] Member 탈퇴 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	testImplementation 'org.mockito:mockito-junit-jupiter'
 	testCompileOnly 'org.projectlombok:lombok:1.18.30'
 	testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 	// H2 Database
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/planit/planit/PlanitApplication.java
+++ b/src/main/java/com/planit/planit/PlanitApplication.java
@@ -3,8 +3,10 @@ package com.planit.planit;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PlanitApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/planit/planit/common/api/member/status/MemberErrorStatus.java
+++ b/src/main/java/com/planit/planit/common/api/member/status/MemberErrorStatus.java
@@ -13,6 +13,8 @@ public enum MemberErrorStatus implements ErrorResponse {
     MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER4002", "이미 가입된 회원입니다."),
     @ExplainError("약관 동의가 완료된 회원")
     MEMBER_ALREADY_SIGN_UP_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER4003", "약관 동의가 완료된 회원입니다."),
+    @ExplainError("이미 탈퇴한 회원")
+    ALREADY_INACTIVE(HttpStatus.BAD_REQUEST, "MEMBER4004", "이미 탈퇴한 회원입니다."),
 
     // 길티프리
     @ExplainError("길티프리는 주 1회만 활성화 가능")

--- a/src/main/java/com/planit/planit/common/api/member/status/MemberSuccessStatus.java
+++ b/src/main/java/com/planit/planit/common/api/member/status/MemberSuccessStatus.java
@@ -27,8 +27,8 @@ public enum MemberSuccessStatus implements SuccessResponse {
     MEMBER_INFO_FETCHED(HttpStatus.OK,"MEMBER2023", "회원 정보가 성공적으로 조회되었습니다." ),
     FCM_TOKEN_SAVED(HttpStatus.OK,"MEMBER2024", "FCM토큰이 저장되었습니다." ),
     FCM_TOKEN_FOUND(HttpStatus.OK,"MEMBER2025" , "FCM토큰이 조회되었습니다." ),
-    FCM_TOKEN_DELETED(HttpStatus.OK,"MEMBER2026", "FCM 토큰이 삭제되었습니다." )
-    ;
+    FCM_TOKEN_DELETED(HttpStatus.OK,"MEMBER2026", "FCM 토큰이 삭제되었습니다." ),
+    MEMBER_DELETED(HttpStatus.OK,"MEMBER2027" , "회원이 성공적으로 탈퇴하였습니다." );
 
 
 

--- a/src/main/java/com/planit/planit/config/SchedulingConfig.java
+++ b/src/main/java/com/planit/planit/config/SchedulingConfig.java
@@ -1,0 +1,23 @@
+package com.planit.planit.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+import java.util.concurrent.Executors;
+
+/**
+ * 스케줄러 설정
+ * - 스케줄러가 사용할 스레드 풀 설정
+ * - 기본적으로 단일 스레드로 실행되지만, 여러 스케줄러가 동시에 실행될 수 있도록 스레드 풀 설정
+ */
+@Configuration
+public class SchedulingConfig implements SchedulingConfigurer {
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        // 스케줄러용 스레드 풀 설정 (기본값: 1개 스레드)
+        // 여러 스케줄러가 동시에 실행될 수 있도록 스레드 풀 크기를 늘림
+        taskRegistrar.setScheduler(Executors.newScheduledThreadPool(5));
+    }
+} 

--- a/src/main/java/com/planit/planit/member/Member.java
+++ b/src/main/java/com/planit/planit/member/Member.java
@@ -153,6 +153,11 @@ public class Member extends BaseEntity {
         this.inactive = LocalDateTime.now();
     }
 
+    // 테스트 전용: inactive 값을 임의로 세팅
+    public void setInactiveForTest(LocalDateTime inactive) {
+        this.inactive = inactive;
+    }
+
     public void activateGuiltyFree(GuiltyFree guiltyFree) {
 
         // 길티프리 활성화
@@ -215,4 +220,5 @@ public class Member extends BaseEntity {
     public void addGuiltyFree(GuiltyFree guiltyFree) {
         this.guiltyFrees.add(guiltyFree);
     }
+
 }

--- a/src/main/java/com/planit/planit/member/repository/MemberRepository.java
+++ b/src/main/java/com/planit/planit/member/repository/MemberRepository.java
@@ -12,4 +12,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     Boolean existsByEmail(String email);
     Optional<Member> findByEmailAndSignType(String email, SignType signType);
+    Optional<Member> findByEmailAndInactiveIsNull(String email);
 }

--- a/src/main/java/com/planit/planit/member/service/MemberScheduler.java
+++ b/src/main/java/com/planit/planit/member/service/MemberScheduler.java
@@ -1,0 +1,49 @@
+package com.planit.planit.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 회원 관련 스케줄러
+ * - 31일 경과한 탈퇴 회원 자동 삭제
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberScheduler {
+
+    private final MemberService memberService;
+
+    /**
+     * 주석 처리된 스케줄러는 실제 운영에서 사용되는 스케줄러
+     * 매일 새벽 2시에 31일 경과한 탈퇴 회원을 삭제
+     * cron 표현식: 초 분 시 일 월 요일
+     * 0 0 2 * * ? = 매일 새벽 2시 정각
+     */
+     @Scheduled(cron = "0 0 2 * * ?")
+     public void deleteInactiveMembersScheduler() {
+         log.info("[스케줄러] 31일 경과 탈퇴 회원 삭제 작업 시작");
+         try {
+             memberService.deleteInactiveMembers();
+             log.info("[스케줄러] 31일 경과 탈퇴 회원 삭제 작업 완료");
+         } catch (Exception e) {
+             log.error("[스케줄러] 31일 경과 탈퇴 회원 삭제 작업 중 오류 발생: {}", e.getMessage(), e);
+         }
+     }
+
+    /**
+     * 개발/테스트용: 1분마다 실행 (실제 운영에서는 주석 처리)
+     */
+//    @Scheduled(fixedRate = 60000) // 60초 = 1분
+//    public void deleteInactiveMembersSchedulerForTest() {
+//        log.info("[스케줄러-테스트] 31일 경과 탈퇴 회원 삭제 작업 시작");
+//        try {
+//            memberService.deleteInactiveMembers();
+//            log.info("[스케줄러-테스트] 31일 경과 탈퇴 회원 삭제 작업 완료");
+//        } catch (Exception e) {
+//            log.error("[스케줄러-테스트] 31일 경과 탈퇴 회원 삭제 작업 중 오류 발생: {}", e.getMessage(), e);
+//        }
+//    }
+} 

--- a/src/main/java/com/planit/planit/member/service/MemberService.java
+++ b/src/main/java/com/planit/planit/member/service/MemberService.java
@@ -20,4 +20,8 @@ public interface MemberService {
     LocalDateTime completeTermsAgreement(String signUpToken);
 
     MemberInfoResponseDTO getMemberInfo(Long memberId);
+
+    void inactivateMember(Long memberId);
+
+    void deleteInactiveMembers();
 }

--- a/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
@@ -154,21 +154,30 @@ public class MemberServiceImpl implements MemberService {
     /**
      * 회원 탈퇴(soft delete) - inactive에 현재 시간 기록
      */
+    @Override
     public void inactivateMember(Long memberId) {
+        log.info("[회원탈퇴] 탈퇴 요청 - memberId: {}", memberId);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
         member.inactivate();
         memberRepository.save(member);
+        log.info("[회원탈퇴] 탈퇴 처리 완료 - memberId: {}", memberId);
     }
 
     /**
      * 31일 경과한 탈퇴 회원 hard delete (스케줄러에서 호출)
      */
+    @Override   
     public void deleteInactiveMembers() {
+        log.info("[회원탈퇴] 31일 경과 회원 하드 딜리트 시작");
         LocalDateTime threshold = LocalDateTime.now().minusDays(31);
         memberRepository.findAll().stream()
                 .filter(m -> m.getInactive() != null && m.getInactive().isBefore(threshold))
-                .forEach(m -> memberRepository.deleteById(m.getId()));
+                .forEach(m -> {
+                    memberRepository.deleteById(m.getId());
+                    log.info("[회원탈퇴] 하드 딜리트 완료 - memberId: {}", m.getId());
+                });
+        log.info("[회원탈퇴] 31일 경과 회원 하드 딜리트 종료");
     }
 
 }

--- a/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
@@ -151,4 +151,24 @@ public class MemberServiceImpl implements MemberService {
 //        member.updateInfo(request.getName(), request.getEmail());
 //    }
 
+    /**
+     * 회원 탈퇴(soft delete) - inactive에 현재 시간 기록
+     */
+    public void inactivateMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+        member.inactivate();
+        memberRepository.save(member);
+    }
+
+    /**
+     * 31일 경과한 탈퇴 회원 hard delete (스케줄러에서 호출)
+     */
+    public void deleteInactiveMembers() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(31);
+        memberRepository.findAll().stream()
+                .filter(m -> m.getInactive() != null && m.getInactive().isBefore(threshold))
+                .forEach(m -> memberRepository.deleteById(m.getId()));
+    }
+
 }

--- a/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
@@ -159,6 +159,9 @@ public class MemberServiceImpl implements MemberService {
         log.info("[회원탈퇴] 탈퇴 요청 - memberId: {}", memberId);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+        if (member.getInactive() != null) {
+            throw new MemberHandler(MemberErrorStatus.ALREADY_INACTIVE);
+        }
         member.inactivate();
         memberRepository.save(member);
         log.info("[회원탈퇴] 탈퇴 처리 완료 - memberId: {}", memberId);

--- a/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
@@ -156,7 +156,6 @@ public class MemberServiceImpl implements MemberService {
      */
     @Override
     public void inactivateMember(Long memberId) {
-        log.info("[회원탈퇴] 탈퇴 요청 - memberId: {}", memberId);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
         if (member.getInactive() != null) {

--- a/src/main/java/com/planit/planit/web/controller/MemberController.java
+++ b/src/main/java/com/planit/planit/web/controller/MemberController.java
@@ -165,11 +165,12 @@ public class MemberController {
     }
 
     @Operation(summary = "[MEMBER] 회원 탈퇴", description = "로그인한 사용자가 회원 탈퇴(soft delete)를 요청합니다.")
+    @SecurityRequirement(name = "accessToken")
     @ApiErrorCodeExample(value = MemberErrorStatus.class, codes = {"MEMBER_NOT_FOUND", "ALREADY_INACTIVE"})
     @PatchMapping("/delete")
     public ResponseEntity<ApiResponse<Void>> deleteMember(@AuthenticationPrincipal UserPrincipal principal) {
         memberService.inactivateMember(principal.getId());
-        log.info("[회원탈퇴] 컨트롤러 - 탈퇴 요청 완료: memberId={}", principal.getId());
+        log.info("✅ [회원탈퇴] 컨트롤러 - 탈퇴 요청 완료: memberId={}", principal.getId());
         return ApiResponse.onSuccess(MemberSuccessStatus.MEMBER_DELETED);
     }
 }

--- a/src/main/java/com/planit/planit/web/controller/MemberController.java
+++ b/src/main/java/com/planit/planit/web/controller/MemberController.java
@@ -163,4 +163,13 @@ public class MemberController {
         log.info("🗑️ FCM 토큰 삭제 완료 - memberId: {}", principal.getId());
         return ApiResponse.onSuccess(MemberSuccessStatus.FCM_TOKEN_DELETED);
     }
+
+    @Operation(summary = "[MEMBER] 회원 탈퇴", description = "로그인한 사용자가 회원 탈퇴(soft delete)를 요청합니다.")
+    @ApiErrorCodeExample(value = MemberErrorStatus.class, codes = {"MEMBER_NOT_FOUND", "ALREADY_INACTIVE"})
+    @PatchMapping("/delete")
+    public ResponseEntity<ApiResponse<Void>> deleteMember(@AuthenticationPrincipal UserPrincipal principal) {
+        memberService.inactivateMember(principal.getId());
+        log.info("[회원탈퇴] 컨트롤러 - 탈퇴 요청 완료: memberId={}", principal.getId());
+        return ApiResponse.onSuccess(MemberSuccessStatus.MEMBER_DELETED);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:prod}  # 기본 dev
+    active: ${SPRING_PROFILES_ACTIVE:dev}  # 기본 dev
     include: oauth
       # 필요시 password, timeout 등 추가 가능
   jackson:

--- a/src/test/java/com/planit/planit/member/service/MemberSchedulerTest.java
+++ b/src/test/java/com/planit/planit/member/service/MemberSchedulerTest.java
@@ -1,0 +1,46 @@
+package com.planit.planit.member.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberSchedulerTest {
+
+    @Mock
+    private MemberService memberService;
+
+    @InjectMocks
+    private MemberScheduler memberScheduler;
+
+    @Test
+    @DisplayName("스케줄러가 정상적으로 deleteInactiveMembers를 호출한다")
+    void testDeleteInactiveMembersScheduler() {
+        // given
+        doNothing().when(memberService).deleteInactiveMembers();
+
+        // when
+        memberScheduler.deleteInactiveMembersScheduler();
+
+        // then
+        verify(memberService, times(1)).deleteInactiveMembers();
+    }
+
+    @Test
+    @DisplayName("스케줄러 실행 중 예외가 발생해도 로그만 남기고 정상 종료된다")
+    void testDeleteInactiveMembersScheduler_withException() {
+        // given
+        doThrow(new RuntimeException("테스트 예외")).when(memberService).deleteInactiveMembers();
+
+        // when & then
+        // 예외가 발생해도 테스트가 실패하지 않아야 함
+        memberScheduler.deleteInactiveMembersScheduler();
+        
+        verify(memberService, times(1)).deleteInactiveMembers();
+    }
+} 

--- a/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
@@ -102,7 +102,7 @@ class MemberServiceImplTest {
                 .role(Role.USER)
                 .build();
         member.inactivate();
-        member.setInactive(LocalDateTime.now().minusDays(31));
+        member.setInactiveForTest(LocalDateTime.now().minusDays(31));
         when(memberRepository.findAll()).thenReturn(java.util.List.of(member));
         doNothing().when(memberRepository).deleteById(anyLong());
 

--- a/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDateTime;
 import java.util.Optional;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -16,6 +18,7 @@ import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
+@Transactional
 class MemberServiceImplTest {
     @Mock
     private MemberRepository memberRepository;

--- a/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
@@ -105,7 +105,7 @@ class MemberServiceImplTest {
                 .role(Role.USER)
                 .build();
         member.inactivate();
-        member.setInactiveForTest(LocalDateTime.now().minusDays(31));
+        member.setInactiveForTest(LocalDateTime.now().minusDays(32));
         when(memberRepository.findAll()).thenReturn(java.util.List.of(member));
         doNothing().when(memberRepository).deleteById(anyLong());
 

--- a/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/planit/planit/member/service/MemberServiceImplTest.java
@@ -1,21 +1,116 @@
 package com.planit.planit.member.service;
 
-import com.planit.planit.auth.oauth.SocialTokenVerifier;
+import com.planit.planit.member.Member;
+import com.planit.planit.member.enums.Role;
+import com.planit.planit.member.enums.SignType;
+import com.planit.planit.member.repository.MemberRepository;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@Transactional
 class MemberServiceImplTest {
-    @MockBean
-    private SocialTokenVerifier socialTokenVerifier;
-
+    @Mock
+    private MemberRepository memberRepository;
     @InjectMocks
     private MemberServiceImpl memberServiceImpl;
+
+    @Test
+    @DisplayName("회원 탈퇴 시 inactive에 시간이 기록된다 (soft delete)")
+    void testSoftDelete_setsInactiveTime() {
+        // given
+        Member member = Member.builder()
+                .email("test@planit.com")
+                .password("pw1234")
+                .signType(SignType.GOOGLE)
+                .guiltyFreeMode(false)
+                .memberName("테스터")
+                .role(Role.USER)
+                .build();
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+
+        // when
+        memberServiceImpl.inactivateMember(1L);
+
+        // then
+        assertNotNull(member.getInactive(), "inactive 필드가 null이 아니어야 한다");
+        verify(memberRepository).save(member);
+    }
+
+    @Test
+    @DisplayName("탈퇴한 회원은 로그인/조회가 불가능하다")
+    void testSoftDeletedMember_cannotLoginOrBeQueried() {
+        // given
+        Member member = Member.builder()
+                .email("test2@planit.com")
+                .password("pw1234")
+                .signType(SignType.GOOGLE)
+                .guiltyFreeMode(false)
+                .memberName("테스터2")
+                .role(Role.USER)
+                .build();
+        member.inactivate();
+        when(memberRepository.findByEmailAndInactiveIsNull("test2@planit.com")).thenReturn(Optional.empty());
+
+        // when
+        Optional<Member> found = memberRepository.findByEmailAndInactiveIsNull("test2@planit.com");
+
+        // then
+        assertTrue(found.isEmpty(), "탈퇴 회원은 조회/로그인 불가");
+    }
+
+    @Test
+    @DisplayName("탈퇴 회원은 DB에서 삭제되지 않는다 (soft delete)")
+    void testSoftDeletedMember_stillExistsInDb() {
+        // given
+        Member member = Member.builder()
+                .email("test3@planit.com")
+                .password("pw1234")
+                .signType(SignType.GOOGLE)
+                .guiltyFreeMode(false)
+                .memberName("테스터3")
+                .role(Role.USER)
+                .build();
+        member.inactivate();
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+
+        // when
+        Optional<Member> found = memberRepository.findById(1L);
+
+        // then
+        assertTrue(found.isPresent(), "DB에는 여전히 존재해야 한다");
+    }
+
+    @Test
+    @DisplayName("30일 지난 탈퇴 회원은 스케줄러에 의해 hard delete 된다")
+    void testScheduler_hardDeletesAfter30Days() {
+        // given
+        Member member = Member.builder()
+                .id(1L)
+                .email("test4@planit.com")
+                .password("pw1234")
+                .signType(SignType.GOOGLE)
+                .guiltyFreeMode(false)
+                .memberName("테스터4")
+                .role(Role.USER)
+                .build();
+        member.inactivate();
+        member.setInactive(LocalDateTime.now().minusDays(31));
+        when(memberRepository.findAll()).thenReturn(java.util.List.of(member));
+        doNothing().when(memberRepository).deleteById(anyLong());
+
+        // when
+        memberServiceImpl.deleteInactiveMembers();
+
+        // then
+        verify(memberRepository).deleteById(anyLong());
+    }
 }
 

--- a/src/test/java/com/planit/planit/web/controller/MemberControllerTest.java
+++ b/src/test/java/com/planit/planit/web/controller/MemberControllerTest.java
@@ -1,19 +1,36 @@
 package com.planit.planit.web.controller;
 
+import com.planit.planit.auth.jwt.UserPrincipal;
+import com.planit.planit.common.api.member.MemberHandler;
+import com.planit.planit.common.api.member.status.MemberErrorStatus;
+import com.planit.planit.member.enums.Role;
 import com.planit.planit.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 
+import static org.mockito.Mockito.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@WebMvcTest(MemberController.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "oauth.google.client-id=dummy",
+        "oauth.google.playground-client-id=dummy"
+})
 class MemberControllerTest {
 
     @Autowired
@@ -22,17 +39,64 @@ class MemberControllerTest {
     @MockBean
     private MemberService memberService;
 
-    @Test
-    @DisplayName("회원 탈퇴 성공 - PATCH /members/delete")
-    @WithMockUser(username = "1") // 인증된 사용자 시뮬레이션, principal.getId()가 1L이라고 가정
-    void deleteMember_success() throws Exception {
-        // given: memberService mock 세팅 (필요시)
-        Mockito.doNothing().when(memberService).inactivateMember(Mockito.anyLong());
-
-        // when & then
-        mockMvc.perform(patch("/members/delete"))
-                .andExpect(status().isOk());
+    private UserPrincipal mockPrincipal() {
+        return new UserPrincipal(1L, "test@planit.com", "푸바오", Role.USER);
     }
 
-    // 추가 테스트: 인증 없는 요청, 이미 탈퇴한 회원 등은 추후 확장 가능
+    private UsernamePasswordAuthenticationToken auth(UserPrincipal principal) {
+        return new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 성공")
+    void deleteMember_success() throws Exception {
+        UserPrincipal principal = mockPrincipal();
+        doNothing().when(memberService).inactivateMember(principal.getId());
+
+        mockMvc.perform(patch("/planit/members/delete")
+                        .with(csrf())
+                        .with(authentication(auth(principal))))
+                .andExpect(status().isOk());
+
+        verify(memberService).inactivateMember(principal.getId());
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자는 403 반환")
+    void deleteMember_unauthenticated() throws Exception {
+        mockMvc.perform(patch("/planit/members/delete").with(csrf()))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("이미 탈퇴한 회원은 예외 발생")
+    void deleteMember_alreadyInactive() throws Exception {
+        UserPrincipal principal = mockPrincipal();
+        doThrow(new MemberHandler(MemberErrorStatus.ALREADY_INACTIVE))
+                .when(memberService).inactivateMember(principal.getId());
+
+        mockMvc.perform(patch("/planit/members/delete")
+                        .with(csrf())
+                        .with(authentication(auth(principal))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("MEMBER4004"));
+
+        verify(memberService).inactivateMember(principal.getId());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원은 예외 발생")
+    void deleteMember_memberNotFound() throws Exception {
+        UserPrincipal principal = mockPrincipal();
+        doThrow(new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND))
+                .when(memberService).inactivateMember(principal.getId());
+
+        mockMvc.perform(patch("/planit/members/delete")
+                        .with(csrf())
+                        .with(authentication(auth(principal))))
+                .andExpect(status().isNotFound());
+
+        verify(memberService).inactivateMember(principal.getId());
+    }
 }

--- a/src/test/java/com/planit/planit/web/controller/MemberControllerTest.java
+++ b/src/test/java/com/planit/planit/web/controller/MemberControllerTest.java
@@ -1,0 +1,38 @@
+package com.planit.planit.web.controller;
+
+import com.planit.planit.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("회원 탈퇴 성공 - PATCH /members/delete")
+    @WithMockUser(username = "1") // 인증된 사용자 시뮬레이션, principal.getId()가 1L이라고 가정
+    void deleteMember_success() throws Exception {
+        // given: memberService mock 세팅 (필요시)
+        Mockito.doNothing().when(memberService).inactivateMember(Mockito.anyLong());
+
+        // when & then
+        mockMvc.perform(patch("/members/delete"))
+                .andExpect(status().isOk());
+    }
+
+    // 추가 테스트: 인증 없는 요청, 이미 탈퇴한 회원 등은 추후 확장 가능
+}


### PR DESCRIPTION
## 연관된 이슈

> 이슈 번호를 작성해주세요

-  #155 

<br>

## 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

# 회원 탈퇴 API 구현

### 1. 엔드포인트
- **URL**: `PATCH /planit/members/delete`
- **방법**: `PATCH`
- **설명**: 회원 탈퇴 처리 (Soft Delete 방식)

### 2. Soft Delete 방식
회원 탈퇴 시 `inactive` 필드에 현재 시간을 기록하여 탈퇴 상태를 관리합니다.

### 3. 자동 회원 삭제 스케줄러
- **기능**: 탈퇴한 후 31일이 경과한 회원은 자동으로 Hard Delete 됩니다.
- **스케줄**: 매일 새벽 2시에 스케줄러가 실행됩니다.
- **Cron Expression**: `@Scheduled(cron = "0 0 2 * * ?")`

### 4. 에러 핸들링 및 응답 상태
- **ALREADY_INACTIVE**: 이미 탈퇴한 회원에 대한 에러 상태를 추가하여 처리합니다.
- **MEMBER_DELETED**: 성공적으로 탈퇴한 회원에 대해 성공 상태를 반환합니다.

### 5. 로그 메시지 추가
탈퇴 처리 과정에서 발생하는 중요한 이벤트에 대한 로그를 추가하여 시스템 모니터링과 디버깅을 용이하게 합니다.
- **예시 로그**:
  - "회원 탈퇴 처리 시작: 회원 ID {memberId}"
  - "회원 탈퇴 처리 완료: 회원 ID {memberId}"
  - "탈퇴 후 31일 경과한 회원 {memberId} 자동 삭제"
  - "이미 탈퇴한 회원 {memberId} 에러 발생"

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회원 탈퇴(비활성화) API 엔드포인트가 추가되어 사용자가 계정을 비활성화할 수 있습니다.
  * 31일 이상 비활성화된 회원을 자동으로 삭제하는 스케줄러 기능이 도입되었습니다.

* **버그 수정**
  * 이미 탈퇴한 회원에 대한 오류 메시지와 코드가 개선되었습니다.

* **환경설정**
  * 기본 활성 Spring 프로필이 "prod"에서 "dev"로 변경되었습니다.

* **테스트**
  * 회원 비활성화 및 자동 삭제 기능에 대한 단위/통합 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->