### PR TITLE
[PL-188] [task] 오늘의 플랜 조회시 작업이 없는 플랜은 반환하지 않도록 수정

### DIFF
--- a/src/main/java/com/planit/planit/plan/service/PlanQueryServiceImpl.java
+++ b/src/main/java/com/planit/planit/plan/service/PlanQueryServiceImpl.java
@@ -38,6 +38,7 @@ public class PlanQueryServiceImpl implements PlanQueryService {
                 .findAllByMemberIdAndPlanStatus(memberId, PlanStatus.IN_PROGRESS).stream()
                 .filter(plan -> plan.getFinishedAt() == null ||
                         (plan.getFinishedAt().isAfter(todayDate) || plan.getFinishedAt().isEqual(todayDate)))
+                .filter(plan -> !plan.getTasks().isEmpty())
                 .toList();
 
         return PlanConverter.toTodayPlanListDTO(todayDate, todayPlans);

--- a/src/test/java/com/planit/planit/plan/service/PlanQueryServiceTest.java
+++ b/src/test/java/com/planit/planit/plan/service/PlanQueryServiceTest.java
@@ -147,8 +147,6 @@ class PlanQueryServiceTest {
         assertThat(result.getTodayDate()).isEqualTo(LocalDate.now());
         assertThat(result.getSlowPlans().get(0).getTitle()).isEqualTo("1");
         assertThat(result.getSlowPlans().get(0).getDDay()).isEqualTo("D-Day");
-        assertThat(result.getPassionatePlans().get(1).getTitle()).isEqualTo("2");
-        assertThat(result.getPassionatePlans().get(1).getDDay()).isEqualTo("D-1");
     }
 
 /*------------------------------ 플랜 단건 조회 ------------------------------*/


### PR DESCRIPTION
## 연관된 이슈

> 이슈 번호를 작성해주세요

- #158 

<br>

## 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- 오늘의 플랜 조회시 작업이 없는 플랜은 반환하지 않도록 수정

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 오늘의 플랜 목록에서 할 일이 없는 플랜이 제외되어, 최소 한 개 이상의 할 일을 가진 플랜만 표시됩니다.

* **테스트**
  * 오늘의 플랜 목록 관련 테스트가 최신 동작에 맞게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->