### PR TITLE
Hotfix: "탈퇴 회원 로그인시 신규 회원 저장 로직변경" 

### DIFF
--- a/src/main/java/com/planit/planit/member/Member.java
+++ b/src/main/java/com/planit/planit/member/Member.java
@@ -28,6 +28,9 @@ import org.springframework.util.Assert;
 
 @Getter
 @Entity
+@Table(uniqueConstraints = {
+    @UniqueConstraint(name = "uk_email_inactive", columnNames = {"email", "inactive"})
+})
 public class Member extends BaseEntity {
 
     @Id
@@ -35,7 +38,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false, unique = true)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
 
     @Column(nullable = false, length = 15)

--- a/src/main/java/com/planit/planit/member/repository/MemberRepository.java
+++ b/src/main/java/com/planit/planit/member/repository/MemberRepository.java
@@ -9,8 +9,8 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
+    // 활성 회원만 조회 (inactive가 null인 회원)
+    Optional<Member> findByEmailAndInactiveIsNull(String email);
     Boolean existsByEmail(String email);
     Optional<Member> findByEmailAndSignType(String email, SignType signType);
-    Optional<Member> findByEmailAndInactiveIsNull(String email);
 }

--- a/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/planit/planit/member/service/MemberServiceImpl.java
@@ -41,15 +41,19 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public SignedMember getSignedMemberByUserInfo(String email, String name, SignType signType) {
-        Member member = memberRepository.findByEmail(email).orElse(null);
+        // 활성 회원만 조회 (inactive가 null인 회원)
+        Member member = memberRepository.findByEmailAndInactiveIsNull(email).orElse(null);
+        
         // 사용자가 존재하지 않으면 신규 회원을 생성하여 반환
         if (member == null) {
             return SignedMember.of(saveMember(email, name, signType), true);
         }
+        
         // 다른 로그인 타입으로 가입한 회원이면 예외 처리
         if (!member.getSignType().equals(signType)) {
             throw new MemberHandler(MemberErrorStatus.DIFFERENT_SIGN_TYPE);
         }
+        
         return SignedMember.of(member, false);
     }
 


### PR DESCRIPTION
## 연관된 이슈

> 이슈 번호를 작성해주세요

- (#을 입력하고 해당하는 이슈번호에서 엔터!)

<br>

## 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

### 요구사항
회원 탈퇴 요청을 한 유저가 signIn할 때, `inActive` 필드에 값이 있는지 확인하고, 있으면 새로운 유저로 회원가입 처리하도록 로직 변경

### 주요 변경사항

#### 1. Member 엔티티 수정
- `email` 필드의 `unique = true` 제약조건 제거
- 복합 unique 제약조건 `(email, inactive)` 추가
- 이를 통해 같은 이메일이라도 `inactive` 값이 다르면 다른 회원으로 처리

```java
@Table(uniqueConstraints = {
    @UniqueConstraint(name = "uk_email_inactive", columnNames = {"email", "inactive"})
})
public class Member extends BaseEntity {
    @Column(nullable = false)  // unique 제거
    private String email;
    
    @Column
    private LocalDateTime inactive;
}
```

#### 2. MemberRepository 수정
- `findByEmail(String email)` 메서드 제거
- 활성 회원만 조회하는 `findByEmailAndInactiveIsNull(String email)` 메서드 사용
- 이를 통해 탈퇴한 회원은 조회되지 않음

#### 3. MemberServiceImpl 로직 수정
- `getSignedMemberByUserInfo` 메서드에서 활성 회원만 조회하도록 변경
- 탈퇴한 회원이 로그인할 때 새로운 회원으로 가입하도록 처리

```java
@Override
public SignedMember getSignedMemberByUserInfo(String email, String name, SignType signType) {
    // 활성 회원만 조회 (inactive가 null인 회원)
    Member member = memberRepository.findByEmailAndInactiveIsNull(email).orElse(null);
    
    // 사용자가 존재하지 않으면 신규 회원을 생성하여 반환
    if (member == null) {
        return SignedMember.of(saveMember(email, name, signType), true);
    }
    
    // 다른 로그인 타입으로 가입한 회원이면 예외 처리
    if (!member.getSignType().equals(signType)) {
        throw new MemberHandler(MemberErrorStatus.DIFFERENT_SIGN_TYPE);
    }
    
    return SignedMember.of(member, false);
}
```

#### 4. 테스트 코드 수정 및 추가
- 기존 중복 이메일 테스트를 새로운 로직에 맞게 수정
- 탈퇴한 회원이 로그인할 때 새로운 회원으로 가입하는 테스트 추가
- 복합 unique 제약조건이 제대로 작동하는지 확인하는 테스트 추가

### 동작 방식

1. **활성 회원**: `email="test@example.com"`, `inactive=null`
2. **탈퇴한 회원**: `email="test@example.com"`, `inactive=2024-01-01 10:00:00`
3. **새로운 회원**: `email="test@example.com"`, `inactive=null`

탈퇴한 회원이 다시 로그인하면 새로운 회원으로 가입되며, 복합 unique 제약조건으로 인해 같은 이메일이라도 `inactive` 값이 다르면 다른 회원으로 처리됩니다.

<br>

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 복합 unique 제약조건 `(email, inactive)`이 적절한지 검토 부탁드립니다
- `findByEmail` 메서드를 제거하고 `findByEmailAndInactiveIsNull`만 사용하는 것이 올바른 접근인지 확인 부탁드립니다
- 탈퇴한 회원의 데이터 보존 정책이 적절한지 검토 부탁드립니다