### PR TITLE
hotfix: "액세스 토큰 재발급 안되는 문제 해결"

### DIFF
--- a/src/main/java/com/planit/planit/common/api/token/status/TokenSuccessStatus.java
+++ b/src/main/java/com/planit/planit/common/api/token/status/TokenSuccessStatus.java
@@ -23,9 +23,7 @@ public enum TokenSuccessStatus implements ErrorResponse, SuccessResponse {
     public HttpStatus getErrorStatus() { return httpStatus; }
 
     @Override
-    public HttpStatus getSuccessStatus() {
-        return null;
-    }
+    public HttpStatus getSuccessStatus() { return httpStatus; }
 
     @Override
     public String getCode() { return code; }

--- a/src/main/java/com/planit/planit/web/controller/AuthController.java
+++ b/src/main/java/com/planit/planit/web/controller/AuthController.java
@@ -65,13 +65,12 @@ public class AuthController {
     @ApiErrorCodeExample(value = com.planit.planit.common.api.token.status.TokenErrorStatus.class, codes = {"INVALID_REFRESH_TOKEN"})
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<TokenRefreshDTO.Response>> refreshToken(
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String refreshTokenHeader
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String refreshToken
     ) {
-        if (refreshTokenHeader == null || !refreshTokenHeader.startsWith("Bearer ")) {
+        if (refreshToken == null) {
             throw new GeneralException(TokenErrorStatus.INVALID_REFRESH_TOKEN);
         }
 
-        String refreshToken = refreshTokenHeader.substring(7);
         TokenRefreshDTO.Response response = authService.refreshAccessToken(refreshToken);
         return ApiResponse.onSuccess(REFRESH_SUCCESS, response);
     }


### PR DESCRIPTION
## 연관된 이슈

> 이슈 번호를 작성해주세요

- (#을 입력하고 해당하는 이슈번호에서 엔터!)

<br>

## 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요(이미지 및 동영상 첨부 가능)

- TokenSuccessState가 null 반환하ㅣ는 문제 해결했습니다.

<br> 

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 토큰 갱신 시 인증 헤더에서 "Bearer " 접두사 제거 없이 토큰을 바로 사용하도록 개선되었습니다.
  * 토큰 관련 성공 상태 반환이 올바른 HTTP 상태값을 반환하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->